### PR TITLE
Add lazy row support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+
+# vhs recordings
+*.gif
+*.mp4
+*.webm
+*.ascii

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,10 +33,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -42,10 +84,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "castaway"
@@ -63,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +144,77 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -112,16 +252,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "either"
@@ -136,10 +323,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -190,6 +435,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +500,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ident_case"
@@ -286,6 +570,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,7 +588,28 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazy_table"
+version = "0.0.0"
+dependencies = [
+ "rand 0.9.5",
+ "ratatui",
+ "ratatui-table",
 ]
 
 [[package]]
@@ -314,8 +630,35 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
@@ -327,16 +670,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "num-traits"
@@ -354,6 +774,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -381,6 +816,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pest"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.8",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +949,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -436,6 +997,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,7 +1060,12 @@ checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
@@ -452,8 +1074,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "compact_str",
+ "critical-section",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
@@ -461,10 +1084,32 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
 ]
 
 [[package]]
@@ -483,12 +1128,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
 name = "ratatui-widgets"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -500,6 +1166,15 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -576,6 +1251,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +1274,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -637,10 +1331,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "static_assertions"
@@ -677,6 +1425,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -698,12 +1457,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.1",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -769,6 +1624,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +1665,208 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,10 +1876,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["examples/apps/*"]
+
 [package]
 name = "ratatui-table"
 version = "0.1.0"
@@ -11,7 +14,7 @@ edition = "2024"
 rust-version = "1.88.0"
 keywords = ["ratatui", "table", "terminal", "tui", "widget"]
 categories = ["command-line-interface", "gui"]
-exclude = [".github", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md"]
+exclude = [".github", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", "examples"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -41,11 +44,14 @@ ratatui = { version = "0.30.2", default-features = false }
 rstest = "0.26"
 serde_json = "1"
 
-[lints.rust]
+[lints]
+workspace = true
+
+[workspace.lints.rust]
 unsafe_code = "forbid"
 unused = { level = "warn", priority = -1 }
 
-[lints.clippy]
+[workspace.lints.clippy]
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
 cast_precision_loss = "allow"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- cargo-rdme start -->
 
-An experimental evolution of Ratatui's built-in [`Table`](https://docs.rs/ratatui-table/latest/ratatui_table/table/struct.Table.html) widget.
+An experimental evolution of Ratatui's built-in [`Table`] widget.
 
 `ratatui-table` starts with the Table implementation from Ratatui main at
 [`3d8639c`]. Version 0.1.0 is intended to render like that built-in Table while giving Table
@@ -43,7 +43,7 @@ let table = Table::new(rows, widths);
 
 ## Ratatui compatibility
 
-[`Table::block`](https://docs.rs/ratatui-table/latest/ratatui_table/table/struct.Table.html#method.block) accepts [`ratatui_widgets::block::Block`](https://docs.rs/ratatui_widgets/latest/ratatui_widgets/block/struct.Block.html) to preserve the built-in API. This
+[`Table::block`] accepts [`ratatui_widgets::block::Block`] to preserve the built-in API. This
 means the initial crate depends on `ratatui-widgets` with default features disabled. A future
 Ratatui facade can re-export this crate without requiring this crate to become part of
 `ratatui-widgets` itself.
@@ -52,7 +52,7 @@ Ratatui facade can re-export this crate without requiring this crate to become p
 
 - `std` enables the standard-library features of the Ratatui dependencies. The Table itself
   remains usable with `no_std` plus `alloc` by default.
-- `serde` adds serialization and deserialization for [`TableState`](https://docs.rs/ratatui-table/latest/ratatui_table/table/state/struct.TableState.html) and [`HighlightSpacing`](https://docs.rs/ratatui-table/latest/ratatui_table/table/highlight_spacing/enum.HighlightSpacing.html).
+- `serde` adds serialization and deserialization for [`TableState`] and [`HighlightSpacing`].
 
 ## Governance
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- cargo-rdme start -->
 
-An experimental evolution of Ratatui's built-in [`Table`] widget.
+An experimental evolution of Ratatui's built-in [`Table`](https://docs.rs/ratatui-table/latest/ratatui_table/table/struct.Table.html) widget.
 
 `ratatui-table` starts with the Table implementation from Ratatui main at
 [`3d8639c`]. Version 0.1.0 is intended to render like that built-in Table while giving Table
@@ -43,7 +43,7 @@ let table = Table::new(rows, widths);
 
 ## Ratatui compatibility
 
-[`Table::block`] accepts [`ratatui_widgets::block::Block`] to preserve the built-in API. This
+[`Table::block`](https://docs.rs/ratatui-table/latest/ratatui_table/table/struct.Table.html#method.block) accepts [`ratatui_widgets::block::Block`](https://docs.rs/ratatui_widgets/latest/ratatui_widgets/block/struct.Block.html) to preserve the built-in API. This
 means the initial crate depends on `ratatui-widgets` with default features disabled. A future
 Ratatui facade can re-export this crate without requiring this crate to become part of
 `ratatui-widgets` itself.
@@ -52,7 +52,7 @@ Ratatui facade can re-export this crate without requiring this crate to become p
 
 - `std` enables the standard-library features of the Ratatui dependencies. The Table itself
   remains usable with `no_std` plus `alloc` by default.
-- `serde` adds serialization and deserialization for [`TableState`] and [`HighlightSpacing`].
+- `serde` adds serialization and deserialization for [`TableState`](https://docs.rs/ratatui-table/latest/ratatui_table/table/state/struct.TableState.html) and [`HighlightSpacing`](https://docs.rs/ratatui-table/latest/ratatui_table/table/highlight_spacing/enum.HighlightSpacing.html).
 
 ## Governance
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Examples
+
+Each example is its own crate under `apps/`, so it can pull in whatever dependencies it needs
+without those reaching the library's own dependency tree.
+
+```shell
+cargo run -p <example_crate>
+```
+
+| example | what it shows |
+| --- | --- |
+| [lazy_table](apps/lazy_table) | a ten-million-entry journal whose rows are built on demand |
+
+These are built against the working tree, not the released crate, so they may use APIs that are
+not published yet.
+
+## Recordings
+
+The tapes in `vhs/` drive the examples for the GIFs in the README and in pull requests. Install
+[VHS], then run one from the repository root:
+
+```shell
+just record lazy_table
+```
+
+The recipe builds the example first and writes `target/<example>.gif`, which is ignored along with
+every other recording. It is deliberately not part of `just check-all`, since VHS is an extra tool
+to install and a recording takes about a minute.
+
+[VHS]: https://github.com/charmbracelet/vhs

--- a/examples/apps/lazy_table/Cargo.toml
+++ b/examples/apps/lazy_table/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lazy_table"
+description = "A ten-million-entry journal viewer built on demand with ratatui-table"
+edition = "2024"
+rust-version = "1.88.0"
+license = "MIT"
+publish = false
+
+[dependencies]
+rand = "0.9"
+ratatui = "0.30.2"
+ratatui-table = { path = "../../.." }
+
+[lints]
+workspace = true

--- a/examples/apps/lazy_table/README.md
+++ b/examples/apps/lazy_table/README.md
@@ -1,0 +1,28 @@
+# Lazy table demo
+
+A journal viewer over ten million entries, none of them stored. The row factory *is* the log, and
+the counter in the status line reports how many entries the last frame actually had to build.
+
+```shell
+cargo run -p lazy_table
+```
+
+| key | effect |
+| --- | --- |
+| `↑` `↓` / `k` `j` | move the selection one entry |
+| `PgUp` `PgDn` | move it twenty entries |
+| `g` `G` / `Home` `End` | jump to the oldest or newest entry |
+| `q` | quit |
+
+Ten million lines is about a month of a chatty service. Collecting them into a `Vec` of rows would
+cost the month; [`Table::lazy_rows`] costs the screen. Hold `↓` for as long as you like, or press
+`G` to land on entry 9,999,999 — the build counter stays at a screenful either way.
+
+`ERROR` entries are three lines tall, carrying an error code and a source location beneath the
+message. That is the job of [`Table::lazy_row_height_with`]: scrolling needs the height of entries
+it will never draw, and a lazy row cannot report its height without being built — which is the
+cost the feature exists to avoid. Severity here is derived from the entry index, so the height is
+known without touching the row.
+
+[`Table::lazy_rows`]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.Table.html#method.lazy_rows
+[`Table::lazy_row_height_with`]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.Table.html#method.lazy_row_height_with

--- a/examples/apps/lazy_table/src/main.rs
+++ b/examples/apps/lazy_table/src/main.rs
@@ -1,0 +1,255 @@
+//! A log viewer over ten million entries.
+//!
+//! ```shell
+//! cargo run -p lazy_table
+//! ```
+//!
+//! Two things to look at:
+//!
+//! - **Rows are built on demand.** There is no `Vec` of entries. [`Table::lazy_rows`] calls the
+//!   factory only for what is on screen, and the factory bumps the counter in the status line, so
+//!   it shows exactly how many entries the last frame cost. Press `G` to jump to entry 9,999,999
+//!   and the count stays at a screenful.
+//! - **Heights are declared apart from the rows.** `ERROR` entries are three lines tall. Scrolling
+//!   needs the height of entries it will never draw, and asking a lazy row for its height would
+//!   mean building it — so [`Table::lazy_row_height_with`] answers from the index alone.
+//!
+//! The log itself is fake but fixed: every entry is worked out from its index, never stored and
+//! never random, because the factory runs again on every frame an entry is visible.
+
+use std::io::Result;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::Block;
+use ratatui::{DefaultTerminal, Frame};
+use ratatui_table::{Cell, Row, Table, TableState};
+
+/// Enough entries that collecting them up front would be the whole cost of the program.
+const ENTRY_COUNT: usize = 10_000_000;
+
+/// Entries are a quarter of a second apart, which puts the tail of the log about a month in.
+const MILLIS_PER_ENTRY: usize = 250;
+
+// Every seventeenth entry failed, every eleventh is a warning, every seventh is debug chatter.
+// The three are coprime, so they never line up into a repeating block.
+const ERROR_EVERY: usize = 17;
+const WARN_EVERY: usize = 11;
+const DEBUG_EVERY: usize = 7;
+
+const SERVICES: [&str; 8] = [
+    "kernel",
+    "systemd",
+    "sshd",
+    "nginx",
+    "postgres",
+    "containerd",
+    "kubelet",
+    "chronyd",
+];
+
+const MESSAGES: [&str; 7] = [
+    "accepted connection, {} open",
+    "request completed in {}ms",
+    "flushed {} pages to disk",
+    "renewed lease, {}s remaining",
+    "reaped {} idle workers",
+    "checkpoint complete, {} segments recycled",
+    "rotated log, {} MiB archived",
+];
+
+const FAILURES: [&str; 5] = [
+    "connection reset by peer",
+    "timed out waiting for lock after {}ms",
+    "checksum mismatch on segment {}",
+    "out of memory, killed worker {}",
+    "write barrier failed on device {}",
+];
+
+const HEADER: [&str; 4] = ["Timestamp", "Level", "Service", "Message"];
+
+const HELP: &str = " ↑/↓ move  PgUp/PgDn page  g/G oldest/newest  q quit ";
+
+fn main() -> Result<()> {
+    ratatui::run(|terminal| App::new().run(terminal))
+}
+
+struct App {
+    state: TableState,
+    /// Bumped once per entry the factory actually builds, and reset before every frame.
+    built: Arc<AtomicUsize>,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            state: TableState::new().with_selected(Some(0)),
+            built: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn run(mut self, terminal: &mut DefaultTerminal) -> Result<()> {
+        loop {
+            terminal.draw(|frame| self.draw(frame))?;
+            if let Event::Key(key) = event::read()?
+                && key.kind == KeyEventKind::Press
+            {
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Down | KeyCode::Char('j') => self.state.select_next(),
+                    KeyCode::Up | KeyCode::Char('k') => self.state.select_previous(),
+                    KeyCode::PageDown => self.jump(20),
+                    KeyCode::PageUp => self.jump(-20),
+                    KeyCode::Char('g') | KeyCode::Home => self.state.select_first(),
+                    KeyCode::Char('G') | KeyCode::End => self.state.select(Some(ENTRY_COUNT - 1)),
+                    _ => {}
+                }
+                // The navigation methods do not know how many entries there are.
+                let selected = self.state.selected().unwrap_or(0).min(ENTRY_COUNT - 1);
+                self.state.select(Some(selected));
+            }
+        }
+    }
+
+    fn jump(&mut self, amount: isize) {
+        let selected = self.state.selected().unwrap_or(0);
+        self.state
+            .select(Some(selected.saturating_add_signed(amount)));
+    }
+
+    fn draw(&mut self, frame: &mut Frame) {
+        let [table_area, status_area, help_area] = Layout::vertical([
+            Constraint::Min(0),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .areas(frame.area());
+
+        self.built.store(0, Ordering::Relaxed);
+        let table = self.table();
+        frame.render_stateful_widget(table, table_area, &mut self.state);
+
+        // Rendered after the table so the count belongs to the frame the viewer is looking at.
+        frame.render_widget(self.status_line(), status_area);
+        frame.render_widget(Line::from(HELP).dim(), help_area);
+    }
+
+    fn table(&self) -> Table<'static> {
+        let widths = [
+            Constraint::Length(14),
+            Constraint::Length(5),
+            Constraint::Length(11),
+            Constraint::Fill(1),
+        ];
+        let built = Arc::clone(&self.built);
+
+        Table::lazy_rows(ENTRY_COUNT, widths, move |index| {
+            built.fetch_add(1, Ordering::Relaxed);
+            entry(index)
+        })
+        // Heights are declared separately because scrolling needs the geometry of entries that
+        // are never drawn. Only the index is needed here, so no row gets built.
+        .lazy_row_height_with(|index| if is_error(index) { 3 } else { 1 })
+        .header(Row::new(HEADER).style(Style::new().bold()))
+        .block(Block::bordered().title(" journal — 10,000,000 entries "))
+        .row_highlight_style(Style::new().bg(Color::Indexed(17)))
+        .highlight_symbol(">> ")
+    }
+
+    fn status_line(&self) -> Line<'static> {
+        let selected = self.state.selected().unwrap_or(0);
+        Line::from(vec![
+            " entry ".into(),
+            thousands(selected).bold(),
+            " of ".into(),
+            thousands(ENTRY_COUNT).bold(),
+            "  │  offset ".into(),
+            thousands(self.state.offset()).bold(),
+            "  │  rows built this frame ".into(),
+            thousands(self.built.load(Ordering::Relaxed))
+                .bold()
+                .fg(Color::Indexed(214)),
+        ])
+    }
+}
+
+/// Whether an entry failed. Kept separate from [`entry`] because the table asks for the height of
+/// entries it never draws, and an `ERROR` is three lines tall.
+const fn is_error(index: usize) -> bool {
+    index.is_multiple_of(ERROR_EVERY)
+}
+
+/// The level column: a label and the colour to print it in.
+const fn level(index: usize) -> (&'static str, Color) {
+    if is_error(index) {
+        ("ERROR", Color::Indexed(203))
+    } else if index.is_multiple_of(WARN_EVERY) {
+        ("WARN", Color::Indexed(214))
+    } else if index.is_multiple_of(DEBUG_EVERY) {
+        ("DEBUG", Color::DarkGray)
+    } else {
+        ("INFO", Color::Indexed(39))
+    }
+}
+
+/// One log entry. This is the whole dataset: a function of the index, stored nowhere.
+fn entry(index: usize) -> Row<'static> {
+    let (label, colour) = level(index);
+
+    // Seeded from the index, so an entry reads the same every time it is drawn. The factory runs
+    // again on every frame the entry is on screen, so an unseeded generator would flicker.
+    let mut rng = StdRng::seed_from_u64(index as u64);
+    let service = SERVICES[rng.random_range(0..SERVICES.len())];
+    let template = if is_error(index) {
+        FAILURES[rng.random_range(0..FAILURES.len())]
+    } else {
+        MESSAGES[rng.random_range(0..MESSAGES.len())]
+    };
+    let message = template.replace("{}", &rng.random_range(12..912).to_string());
+
+    let body = if is_error(index) {
+        Text::from(vec![
+            Line::from(message),
+            Line::from(format!("    code E{:04}", rng.random_range(0..10_000))).dim(),
+            Line::from(format!(
+                "    at src/{service}/handler.rs:{}",
+                rng.random_range(20..820)
+            ))
+            .dim(),
+        ])
+    } else {
+        Text::from(message)
+    };
+
+    Row::new([
+        Cell::from(timestamp(index).dim()),
+        Cell::from(Span::from(label).fg(colour)),
+        Cell::from(Span::from(service).fg(Color::Indexed(108))),
+        Cell::from(body),
+    ])
+}
+
+/// Monotonic since start of capture, the way `dmesg` prints it: `[  12345.750]`.
+fn timestamp(index: usize) -> Span<'static> {
+    let millis = index * MILLIS_PER_ENTRY;
+    Span::from(format!("[{:>7}.{:03}]", millis / 1000, millis % 1000))
+}
+
+/// `1234567` renders as `1,234,567`, so the entry count reads as the point of the example.
+fn thousands(value: usize) -> String {
+    let digits = value.to_string();
+    let mut out = String::new();
+    for (position, digit) in digits.chars().enumerate() {
+        if position > 0 && (digits.len() - position).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(digit);
+    }
+    out
+}

--- a/examples/vhs/lazy_table.tape
+++ b/examples/vhs/lazy_table.tape
@@ -1,0 +1,37 @@
+# Records examples/apps/lazy_table into target/lazy_table.gif. Install
+# https://github.com/charmbracelet/vhs, then run this from the repository root:
+#
+#   just record lazy_table
+
+Output target/lazy_table.gif
+
+Set Shell bash
+Set FontSize 16
+Set Width 1000
+Set Height 520
+Set Padding 12
+
+Hide
+Type "cargo run --quiet -p lazy_table" Enter
+Sleep 4s
+Show
+
+Sleep 1500ms
+
+Down@350ms 8
+Sleep 1500ms
+
+# The long scroll: twenty seconds of held ↓, a thousand entries.
+Down@20ms 1000
+Sleep 2s
+
+PageDown@250ms 12
+Sleep 2s
+
+Type "G"
+Sleep 3s
+Type "g"
+Sleep 3s
+
+Type "q"
+Sleep 1s

--- a/justfile
+++ b/justfile
@@ -23,6 +23,14 @@ test:
     cargo test --no-default-features
     cargo test --no-default-features --features serde
 
+examples:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Record an example with https://github.com/charmbracelet/vhs, into target/<example>.gif
+record example="":
+    cargo build -p "{{example}}"
+    vhs examples/vhs/"{{example}}.tape"
+
 docs:
     RUSTC="$(rustup which --toolchain nightly rustc)" \
       RUSTDOC="$(rustup which --toolchain nightly rustdoc)" \
@@ -47,4 +55,4 @@ semver-checks:
 package:
     cargo package --locked --allow-dirty
 
-check-all: fmt-check clippy-all test docs rdme-check deny minimal-versions semver-checks package
+check-all: fmt-check clippy-all test examples docs rdme-check deny minimal-versions semver-checks package

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,8 +1,12 @@
 //! The [`Table`] widget is used to display multiple rows and columns in a grid and allows selecting
 //! one or multiple cells.
 
+use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::hash::Hasher;
+use core::panic::RefUnwindSafe;
+use core::{fmt, ptr};
 
 use itertools::Itertools;
 use ratatui_core::buffer::Buffer;
@@ -21,6 +25,204 @@ mod cell;
 mod highlight_spacing;
 mod row;
 mod state;
+
+/// Supplies the height of a lazy row *without* building it.
+///
+/// Scrolling has to know the geometry of rows that are never drawn (for instance the rows between
+/// the current offset and a selection further down the table), so heights are described separately
+/// from the rows themselves. This is what keeps variable-height lazy tables correct: the scroll
+/// calculation asks for heights, not for rows.
+enum LazyRowHeights<'a> {
+    /// Every row occupies the same number of lines.
+    Uniform(u16),
+    /// Row heights are computed on demand from the row index.
+    PerRow(Arc<dyn Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'a>),
+}
+
+impl LazyRowHeights<'_> {
+    /// The number of lines occupied by the row at `index`.
+    fn height_of(&self, index: usize) -> u16 {
+        match self {
+            Self::Uniform(height) => *height,
+            Self::PerRow(heights) => heights(index),
+        }
+    }
+}
+
+impl fmt::Debug for LazyRowHeights<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Uniform(height) => f.debug_tuple("Uniform").field(height).finish(),
+            Self::PerRow(_) => f.debug_tuple("PerRow").finish(),
+        }
+    }
+}
+
+impl Clone for LazyRowHeights<'_> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Uniform(height) => Self::Uniform(*height),
+            Self::PerRow(heights) => Self::PerRow(Arc::clone(heights)),
+        }
+    }
+}
+
+impl PartialEq for LazyRowHeights<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Uniform(left), Self::Uniform(right)) => left == right,
+            (Self::PerRow(left), Self::PerRow(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for LazyRowHeights<'_> {}
+
+impl core::hash::Hash for LazyRowHeights<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Uniform(height) => {
+                "uniform".hash(state);
+                height.hash(state);
+            }
+            Self::PerRow(heights) => {
+                "per_row".hash(state);
+                ptr::hash(Arc::as_ptr(heights), state);
+            }
+        }
+    }
+}
+
+/// Stores the parameters needed to build rows on demand for a lazy table.
+struct LazyRowProvider<'a> {
+    count: usize,
+    heights: LazyRowHeights<'a>,
+    factory: Arc<dyn Fn(usize) -> Row<'a> + Send + Sync + RefUnwindSafe + 'a>,
+}
+
+impl LazyRowProvider<'_> {
+    /// The number of lines occupied by the row at `index`.
+    fn height_of(&self, index: usize) -> u16 {
+        self.heights.height_of(index)
+    }
+
+    /// Return the indexes of the visible rows, as [`Table::visible_rows`] does for eager rows.
+    ///
+    /// The algorithm is the same, and produces the same window, but it only ever consults
+    /// [`LazyRowProvider::height_of`] instead of inspecting rows, so no row outside the returned
+    /// range is ever built. In particular, when the selection sits below the window the range is
+    /// anchored *at the selection and grown upwards* rather than scrolled down one row at a time,
+    /// which keeps the work proportional to the visible area rather than to the distance scrolled.
+    ///
+    /// The one case where the two differ is a selected row taller than the whole area: growing the
+    /// window upwards keeps such a row on screen (clipped), where scrolling down one row at a time
+    /// walks past it and leaves it off screen entirely.
+    fn visible_rows(&self, state: &TableState, area: Rect) -> (usize, usize) {
+        if self.count == 0 {
+            return (0, 0);
+        }
+        let last_row = self.count - 1;
+        let selected = state.selected.map(|selected| selected.min(last_row));
+
+        let mut start = state.offset.min(last_row);
+        if let Some(selected) = selected {
+            start = start.min(selected);
+        }
+
+        // An area with no lines shows no rows, but the offset is still where the table would
+        // resume from, so it is returned unchanged rather than reset.
+        if area.height == 0 {
+            return (start, start);
+        }
+
+        // Fill the area downwards from the start with the rows that fit in it completely.
+        let mut end = start;
+        let mut height = 0_u16;
+        while end < self.count {
+            let row_height = self.height_of(end);
+            if height.saturating_add(row_height) > area.height {
+                break;
+            }
+            height += row_height;
+            end += 1;
+            if window_is_full(start, end, area) {
+                break;
+            }
+        }
+
+        // Scroll down until the selected row is visible, by anchoring the window at the selection
+        // and growing it upwards until the area is full.
+        if let Some(selected) = selected
+            && selected >= end
+        {
+            start = selected;
+            end = selected + 1;
+            height = self.height_of(selected);
+            while start > 0 && !window_is_full(start, end, area) {
+                let row_height = self.height_of(start - 1);
+                if height.saturating_add(row_height) > area.height {
+                    break;
+                }
+                height += row_height;
+                start -= 1;
+            }
+        }
+
+        // Include a partial row if there is space
+        if height < area.height && end < self.count && !window_is_full(start, end, area) {
+            end += 1;
+        }
+
+        (start, end)
+    }
+}
+
+/// Whether a window of lazy rows can be grown no further.
+///
+/// A window never holds more rows than the area has lines, plus one partial row. Rows are free to
+/// report a height of zero, so this bound is what keeps [`LazyRowProvider::visible_rows`]
+/// proportional to the area rather than to the number of rows.
+const fn window_is_full(start: usize, end: usize, area: Rect) -> bool {
+    end - start > area.height as usize
+}
+
+impl fmt::Debug for LazyRowProvider<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyRowProvider")
+            .field("count", &self.count)
+            .field("heights", &self.heights)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Clone for LazyRowProvider<'_> {
+    fn clone(&self) -> Self {
+        Self {
+            count: self.count,
+            heights: self.heights.clone(),
+            factory: Arc::clone(&self.factory),
+        }
+    }
+}
+
+impl PartialEq for LazyRowProvider<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.count == other.count
+            && self.heights == other.heights
+            && Arc::ptr_eq(&self.factory, &other.factory)
+    }
+}
+
+impl Eq for LazyRowProvider<'_> {}
+
+impl core::hash::Hash for LazyRowProvider<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.count.hash(state);
+        self.heights.hash(state);
+        ptr::hash(Arc::as_ptr(&self.factory), state);
+    }
+}
 
 /// A widget to display data in formatted columns.
 ///
@@ -77,8 +279,7 @@ mod state;
 /// ```rust
 /// use ratatui::layout::Constraint;
 /// use ratatui::style::{Style, Stylize};
-/// use ratatui::widgets::Block;
-/// use ratatui_table::{Row, Table};
+/// use ratatui::widgets::{Block, Row, Table};
 ///
 /// let rows = [Row::new(vec!["Cell1", "Cell2", "Cell3"])];
 /// // Columns widths are constrained in the same way as Layout...
@@ -117,7 +318,7 @@ mod state;
 /// ```rust
 /// use ratatui::style::{Style, Stylize};
 /// use ratatui::text::{Line, Span};
-/// use ratatui_table::{Cell, Row, Table};
+/// use ratatui::widgets::{Cell, Row, Table};
 ///
 /// // a Row can be created from simple strings.
 /// let row = Row::new(vec!["Row11", "Row12", "Row13"]);
@@ -147,7 +348,7 @@ mod state;
 /// ```rust
 /// use ratatui::style::{Style, Stylize};
 /// use ratatui::text::{Line, Span, Text};
-/// use ratatui_table::Cell;
+/// use ratatui::widgets::Cell;
 ///
 /// Cell::from("simple string");
 /// Cell::from("simple styled span".red());
@@ -203,8 +404,7 @@ mod state;
 /// use ratatui::Frame;
 /// use ratatui::layout::{Constraint, Rect};
 /// use ratatui::style::{Style, Stylize};
-/// use ratatui::widgets::Block;
-/// use ratatui_table::{Row, Table, TableState};
+/// use ratatui::widgets::{Block, Row, Table, TableState};
 ///
 /// # fn ui(frame: &mut Frame) {
 /// # let area = Rect::default();
@@ -271,6 +471,9 @@ pub struct Table<'a> {
 
     /// Controls how to distribute extra space among the columns
     flex: Flex,
+
+    /// Optional lazy row provider used instead of `rows` when set
+    lazy: Option<LazyRowProvider<'a>>,
 }
 
 impl Default for Table<'_> {
@@ -289,6 +492,7 @@ impl Default for Table<'_> {
             highlight_symbol: Text::default(),
             highlight_spacing: HighlightSpacing::default(),
             flex: Flex::Start,
+            lazy: None,
         }
     }
 }
@@ -345,6 +549,8 @@ impl<'a> Table<'a> {
     /// This method does not currently set the column widths. You will need to set them manually by
     /// calling [`Table::widths`].
     ///
+    /// Setting rows explicitly replaces the rows of a table created with [`Table::lazy_rows`].
+    ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     ///
     /// # Examples
@@ -364,6 +570,7 @@ impl<'a> Table<'a> {
         T: IntoIterator<Item = Row<'a>>,
     {
         self.rows = rows.into_iter().collect();
+        self.lazy = None;
         self
     }
 
@@ -376,7 +583,7 @@ impl<'a> Table<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use ratatui_table::{Cell, Row, Table};
+    /// use ratatui::widgets::{Cell, Row, Table};
     ///
     /// let header = Row::new(vec![
     ///     Cell::from("Header Cell 1"),
@@ -399,7 +606,7 @@ impl<'a> Table<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use ratatui_table::{Cell, Row, Table};
+    /// use ratatui::widgets::{Cell, Row, Table};
     ///
     /// let footer = Row::new(vec![
     ///     Cell::from("Footer Cell 1"),
@@ -428,7 +635,7 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui_table::{Cell, Row, Table};
+    /// use ratatui::widgets::{Cell, Row, Table};
     ///
     /// let table = Table::default().widths([Constraint::Length(5), Constraint::Length(5)]);
     /// let table = Table::default().widths(vec![Constraint::Length(5); 2]);
@@ -480,8 +687,7 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui::widgets::Block;
-    /// use ratatui_table::{Cell, Row, Table};
+    /// use ratatui::widgets::{Block, Cell, Row, Table};
     ///
     /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -522,7 +728,7 @@ impl<'a> Table<'a> {
     /// ```rust
     /// use ratatui::layout::Constraint;
     /// use ratatui::style::Stylize;
-    /// use ratatui_table::{Cell, Row, Table};
+    /// use ratatui::widgets::{Cell, Row, Table};
     ///
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = vec![Constraint::Length(5), Constraint::Length(5)];
@@ -552,7 +758,7 @@ impl<'a> Table<'a> {
     /// ```rust
     /// use ratatui::layout::Constraint;
     /// use ratatui::style::{Style, Stylize};
-    /// use ratatui_table::{Cell, Row, Table};
+    /// use ratatui::widgets::{Cell, Row, Table};
     ///
     /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -649,7 +855,7 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui_table::{Cell, Row, Table};
+    /// use ratatui::widgets::{Cell, Row, Table};
     ///
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -683,7 +889,7 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui_table::{HighlightSpacing, Row, Table};
+    /// use ratatui::widgets::{HighlightSpacing, Row, Table};
     ///
     /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -723,6 +929,128 @@ impl<'a> Table<'a> {
         self.flex = flex;
         self
     }
+
+    /// Creates a [`Table`] that builds rows lazily, calling the factory only for visible rows.
+    ///
+    /// Unlike [`Table::new`], which eagerly collects all rows into a `Vec`, this constructor stores
+    /// only the total row count and a factory closure. During rendering the factory is called
+    /// exclusively for the rows that fall within the visible viewport, so memory allocation and
+    /// processing work scale with the visible area rather than the total dataset size.
+    ///
+    /// Rows are one line tall by default. Use [`Table::row_height`] for taller rows, or
+    /// [`Table::row_height_with`] when rows have individual heights.
+    ///
+    /// The `widths` parameter works exactly like [`Table::widths`] and must be provided because
+    /// column layout cannot be inferred from rows that have not yet been built.
+    ///
+    /// # Row geometry
+    ///
+    /// The height configured on the table is authoritative: [`Row::height`], [`Row::top_margin`]
+    /// and [`Row::bottom_margin`] set on rows returned by the factory are ignored, because
+    /// scrolling has to reason about rows that are never built. Include any spacing you want in
+    /// the row height.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui::layout::Constraint;
+    /// use ratatui_table::{Row, Table};
+    ///
+    /// let table = Table::lazy_rows(
+    ///     10_000,
+    ///     [Constraint::Length(20), Constraint::Fill(1)],
+    ///     |index| Row::new([format!("item {index}"), format!("value {index}")]),
+    /// );
+    /// ```
+    pub fn lazy_rows<C, F>(row_count: usize, widths: C, row: F) -> Self
+    where
+        C: IntoIterator,
+        C::Item: Into<Constraint>,
+        F: Fn(usize) -> Row<'a> + Send + Sync + RefUnwindSafe + 'a,
+    {
+        let widths: Vec<Constraint> = widths.into_iter().map(Into::into).collect();
+        ensure_percentages_less_than_100(&widths);
+        Self {
+            lazy: Some(LazyRowProvider {
+                count: row_count,
+                heights: LazyRowHeights::Uniform(1),
+                factory: Arc::new(row),
+            }),
+            widths,
+            ..Default::default()
+        }
+    }
+
+    /// Set the height, in lines, of every lazily built row.
+    ///
+    /// Use [`Table::row_height_with`] when rows have individual heights.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    ///
+    /// # Note
+    ///
+    /// This only affects rows built by [`Table::lazy_rows`]; rows set with [`Table::new`] or
+    /// [`Table::rows`] carry their own [`Row::height`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui::layout::Constraint;
+    /// use ratatui_table::{Row, Table};
+    ///
+    /// let table = Table::lazy_rows(10_000, [Constraint::Length(20)], |index| {
+    ///     Row::new([format!("item {index}")])
+    /// })
+    /// .row_height(2);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn row_height(mut self, height: u16) -> Self {
+        if let Some(ref mut lazy) = self.lazy {
+            lazy.heights = LazyRowHeights::Uniform(height);
+        }
+        self
+    }
+
+    /// Set the height, in lines, of each lazily built row individually.
+    ///
+    /// This is the varying-height counterpart of [`Table::row_height`].
+    ///
+    /// Scrolling needs the geometry of rows that are not on screen — for instance to work out how
+    /// far to scroll back when the selection is below the viewport — which is why heights are
+    /// supplied separately from the rows. `height` should therefore be cheap: it is called for the
+    /// rows in the viewport (and, while anchoring a selection, for a viewport's worth of rows
+    /// around it), but never allocates a [`Row`]. The row factory itself is still only called for
+    /// rows that are actually drawn.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    ///
+    /// # Note
+    ///
+    /// This only affects rows built by [`Table::lazy_rows`]; rows set with [`Table::new`] or
+    /// [`Table::rows`] carry their own [`Row::height`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui::layout::Constraint;
+    /// use ratatui_table::{Row, Table};
+    ///
+    /// // Every tenth row is a double-height separator.
+    /// let table = Table::lazy_rows(10_000, [Constraint::Length(20)], |index| {
+    ///     Row::new([format!("item {index}")])
+    /// })
+    /// .row_height_with(|index| if index % 10 == 0 { 2 } else { 1 });
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn row_height_with<H>(mut self, height: H) -> Self
+    where
+        H: Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'a,
+    {
+        if let Some(ref mut lazy) = self.lazy {
+            lazy.heights = LazyRowHeights::PerRow(Arc::new(height));
+        }
+        self
+    }
 }
 
 impl Widget for Table<'_> {
@@ -757,11 +1085,12 @@ impl StatefulWidget for &Table<'_> {
             return;
         }
 
-        if state.selected.is_some_and(|s| s >= self.rows.len()) {
-            state.select(Some(self.rows.len().saturating_sub(1)));
+        let row_count = self.row_count();
+        if state.selected.is_some_and(|s| s >= row_count) {
+            state.select(Some(row_count.saturating_sub(1)));
         }
 
-        if self.rows.is_empty() {
+        if row_count == 0 {
             state.select(None);
         }
 
@@ -851,6 +1180,11 @@ impl Table<'_> {
         state: &mut TableState,
         columns_widths: &[Rect],
     ) {
+        if let Some(ref provider) = self.lazy {
+            self.render_lazy_rows(area, buf, selection_width, state, columns_widths, provider);
+            return;
+        }
+
         if self.rows.is_empty() {
             return;
         }
@@ -884,6 +1218,64 @@ impl Table<'_> {
             y_offset += row.height_with_margin();
         }
 
+        self.apply_highlight_styles(buf, area, selected_row_area, state, columns_widths);
+    }
+
+    /// Render visible rows from a lazy provider, calling the factory only for the visible range.
+    fn render_lazy_rows(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        selection_width: u16,
+        state: &mut TableState,
+        columns_widths: &[Rect],
+        provider: &LazyRowProvider,
+    ) {
+        if provider.count == 0 {
+            return;
+        }
+
+        let (start_index, end_index) = provider.visible_rows(state, area);
+        state.offset = start_index;
+
+        let mut y = area.y;
+        let mut selected_row_area = None;
+
+        for index in start_index..end_index {
+            let row = (provider.factory)(index);
+            // The provider owns the geometry: a height or margin set on the row would make what is
+            // drawn disagree with the scroll calculation, which never sees the row itself.
+            let row_height = provider.height_of(index);
+            let height = y
+                .saturating_add(row_height)
+                .min(area.bottom())
+                .saturating_sub(y);
+            let row_area = Rect { y, height, ..area };
+            buf.set_style(row_area, row.style);
+
+            let is_selected = state.selected == Some(index);
+            if selection_width > 0 && is_selected {
+                self.set_selection_style(buf, selection_width, row_area, &row);
+            }
+            self.render_row_cells(buf, columns_widths.iter().collect(), &row.cells, row_area);
+            if is_selected {
+                selected_row_area = Some(row_area);
+            }
+            y = y.saturating_add(row_height);
+        }
+
+        self.apply_highlight_styles(buf, area, selected_row_area, state, columns_widths);
+    }
+
+    /// Apply row, column, and cell highlight styles after rows have been rendered.
+    fn apply_highlight_styles(
+        &self,
+        buf: &mut Buffer,
+        area: Rect,
+        selected_row_area: Option<Rect>,
+        state: &TableState,
+        columns_widths: &[Rect],
+    ) {
         let selected_column_area = state.selected_column.and_then(|s| {
             // The selection is clamped by the column count. Since a user can manually specify an
             // incorrect number of widths, we should use panic free methods.
@@ -1067,12 +1459,27 @@ impl Table<'_> {
             .collect()
     }
 
+    /// The number of rows in the table, whether they are stored eagerly or built lazily.
+    fn row_count(&self) -> usize {
+        self.lazy
+            .as_ref()
+            .map_or_else(|| self.rows.len(), |provider| provider.count)
+    }
+
     fn column_count(&self) -> usize {
+        // Lazy rows cannot be inspected without building them, so the column count comes from the
+        // widths (which `Table::lazy_rows` requires) and from the header and footer.
+        let lazy_columns = if self.lazy.is_some() {
+            self.widths.len()
+        } else {
+            0
+        };
         self.rows
             .iter()
             .chain(self.footer.iter())
             .chain(self.header.iter())
             .map(|r| r.cells.len())
+            .chain(Some(lazy_columns))
             .max()
             .unwrap_or_default()
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -137,14 +137,19 @@ impl LazyRowProvider<'_> {
         }
 
         // Fill the area downwards from the start with the rows that fit in it completely.
+        //
+        // `height` only ever takes a checked sum that fits in the area, so a row reporting
+        // `u16::MAX` lines cannot overflow it, and `end` stops at `self.count`.
         let mut end = start;
         let mut height = 0_u16;
         while end < self.count {
-            let row_height = self.height_of(end);
-            if height.saturating_add(row_height) > area.height {
+            let Some(filled) = height.checked_add(self.height_of(end)) else {
+                break;
+            };
+            if filled > area.height {
                 break;
             }
-            height += row_height;
+            height = filled;
             end += 1;
             if window_is_full(start, end, area) {
                 break;
@@ -156,15 +161,19 @@ impl LazyRowProvider<'_> {
         if let Some(selected) = selected
             && selected >= end
         {
+            // `selected <= last_row`, so `selected + 1` cannot overflow, and `start` is only
+            // decremented while it is above zero.
             start = selected;
             end = selected + 1;
             height = self.height_of(selected);
             while start > 0 && !window_is_full(start, end, area) {
-                let row_height = self.height_of(start - 1);
-                if height.saturating_add(row_height) > area.height {
+                let Some(filled) = height.checked_add(self.height_of(start - 1)) else {
+                    break;
+                };
+                if filled > area.height {
                     break;
                 }
-                height += row_height;
+                height = filled;
                 start -= 1;
             }
         }
@@ -279,7 +288,8 @@ impl core::hash::Hash for LazyRowProvider<'_> {
 /// ```rust
 /// use ratatui::layout::Constraint;
 /// use ratatui::style::{Style, Stylize};
-/// use ratatui::widgets::{Block, Row, Table};
+/// use ratatui::widgets::Block;
+/// use ratatui_table::{Row, Table};
 ///
 /// let rows = [Row::new(vec!["Cell1", "Cell2", "Cell3"])];
 /// // Columns widths are constrained in the same way as Layout...
@@ -318,7 +328,7 @@ impl core::hash::Hash for LazyRowProvider<'_> {
 /// ```rust
 /// use ratatui::style::{Style, Stylize};
 /// use ratatui::text::{Line, Span};
-/// use ratatui::widgets::{Cell, Row, Table};
+/// use ratatui_table::{Cell, Row, Table};
 ///
 /// // a Row can be created from simple strings.
 /// let row = Row::new(vec!["Row11", "Row12", "Row13"]);
@@ -348,7 +358,7 @@ impl core::hash::Hash for LazyRowProvider<'_> {
 /// ```rust
 /// use ratatui::style::{Style, Stylize};
 /// use ratatui::text::{Line, Span, Text};
-/// use ratatui::widgets::Cell;
+/// use ratatui_table::Cell;
 ///
 /// Cell::from("simple string");
 /// Cell::from("simple styled span".red());
@@ -404,7 +414,8 @@ impl core::hash::Hash for LazyRowProvider<'_> {
 /// use ratatui::Frame;
 /// use ratatui::layout::{Constraint, Rect};
 /// use ratatui::style::{Style, Stylize};
-/// use ratatui::widgets::{Block, Row, Table, TableState};
+/// use ratatui::widgets::Block;
+/// use ratatui_table::{Row, Table, TableState};
 ///
 /// # fn ui(frame: &mut Frame) {
 /// # let area = Rect::default();
@@ -583,7 +594,7 @@ impl<'a> Table<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use ratatui::widgets::{Cell, Row, Table};
+    /// use ratatui_table::{Cell, Row, Table};
     ///
     /// let header = Row::new(vec![
     ///     Cell::from("Header Cell 1"),
@@ -606,7 +617,7 @@ impl<'a> Table<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// use ratatui::widgets::{Cell, Row, Table};
+    /// use ratatui_table::{Cell, Row, Table};
     ///
     /// let footer = Row::new(vec![
     ///     Cell::from("Footer Cell 1"),
@@ -635,7 +646,7 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui::widgets::{Cell, Row, Table};
+    /// use ratatui_table::{Cell, Row, Table};
     ///
     /// let table = Table::default().widths([Constraint::Length(5), Constraint::Length(5)]);
     /// let table = Table::default().widths(vec![Constraint::Length(5); 2]);
@@ -687,7 +698,8 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui::widgets::{Block, Cell, Row, Table};
+    /// use ratatui::widgets::Block;
+    /// use ratatui_table::{Cell, Row, Table};
     ///
     /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -728,7 +740,7 @@ impl<'a> Table<'a> {
     /// ```rust
     /// use ratatui::layout::Constraint;
     /// use ratatui::style::Stylize;
-    /// use ratatui::widgets::{Cell, Row, Table};
+    /// use ratatui_table::{Cell, Row, Table};
     ///
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = vec![Constraint::Length(5), Constraint::Length(5)];
@@ -758,7 +770,7 @@ impl<'a> Table<'a> {
     /// ```rust
     /// use ratatui::layout::Constraint;
     /// use ratatui::style::{Style, Stylize};
-    /// use ratatui::widgets::{Cell, Row, Table};
+    /// use ratatui_table::{Cell, Row, Table};
     ///
     /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -855,7 +867,7 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui::widgets::{Cell, Row, Table};
+    /// use ratatui_table::{Cell, Row, Table};
     ///
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -889,7 +901,7 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui::widgets::{HighlightSpacing, Row, Table};
+    /// use ratatui_table::{HighlightSpacing, Row, Table};
     ///
     /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// let widths = [Constraint::Length(5), Constraint::Length(5)];
@@ -937,8 +949,8 @@ impl<'a> Table<'a> {
     /// exclusively for the rows that fall within the visible viewport, so memory allocation and
     /// processing work scale with the visible area rather than the total dataset size.
     ///
-    /// Rows are one line tall by default. Use [`Table::row_height`] for taller rows, or
-    /// [`Table::row_height_with`] when rows have individual heights.
+    /// Rows are one line tall by default. Use [`Table::lazy_row_height`] for taller rows, or
+    /// [`Table::lazy_row_height_with`] when rows have individual heights.
     ///
     /// The `widths` parameter works exactly like [`Table::widths`] and must be provided because
     /// column layout cannot be inferred from rows that have not yet been built.
@@ -983,7 +995,7 @@ impl<'a> Table<'a> {
 
     /// Set the height, in lines, of every lazily built row.
     ///
-    /// Use [`Table::row_height_with`] when rows have individual heights.
+    /// Use [`Table::lazy_row_height_with`] when rows have individual heights.
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     ///
@@ -1001,10 +1013,10 @@ impl<'a> Table<'a> {
     /// let table = Table::lazy_rows(10_000, [Constraint::Length(20)], |index| {
     ///     Row::new([format!("item {index}")])
     /// })
-    /// .row_height(2);
+    /// .lazy_row_height(2);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn row_height(mut self, height: u16) -> Self {
+    pub fn lazy_row_height(mut self, height: u16) -> Self {
         if let Some(ref mut lazy) = self.lazy {
             lazy.heights = LazyRowHeights::Uniform(height);
         }
@@ -1013,7 +1025,7 @@ impl<'a> Table<'a> {
 
     /// Set the height, in lines, of each lazily built row individually.
     ///
-    /// This is the varying-height counterpart of [`Table::row_height`].
+    /// This is the varying-height counterpart of [`Table::lazy_row_height`].
     ///
     /// Scrolling needs the geometry of rows that are not on screen — for instance to work out how
     /// far to scroll back when the selection is below the viewport — which is why heights are
@@ -1039,10 +1051,10 @@ impl<'a> Table<'a> {
     /// let table = Table::lazy_rows(10_000, [Constraint::Length(20)], |index| {
     ///     Row::new([format!("item {index}")])
     /// })
-    /// .row_height_with(|index| if index % 10 == 0 { 2 } else { 1 });
+    /// .lazy_row_height_with(|index| if index % 10 == 0 { 2 } else { 1 });
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn row_height_with<H>(mut self, height: H) -> Self
+    pub fn lazy_row_height_with<H>(mut self, height: H) -> Self
     where
         H: Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'a,
     {
@@ -1545,6 +1557,22 @@ mod tests {
 
     use super::*;
     use crate::table::Cell;
+
+    /// A row taller than the remaining space must end the window instead of wrapping the
+    /// running line total, which needs an area tall enough for that total to reach `u16::MAX`.
+    #[test]
+    fn lazy_visible_rows_do_not_overflow_the_line_total() {
+        let table = Table::lazy_rows(4, [Constraint::Length(1)], |_| Row::new(["x"]))
+            .lazy_row_height_with(|index| if index == 0 { u16::MAX } else { 1 });
+        let lazy = table.lazy.as_ref().expect("lazy rows");
+        let area = Rect::new(0, 0, 1, u16::MAX);
+
+        let state = TableState::default();
+        assert_eq!(lazy.visible_rows(&state, area), (0, 1));
+
+        let state = TableState::default().with_selected(3);
+        assert_eq!(lazy.visible_rows(&state, area), (1, 4));
+    }
 
     #[test]
     fn new() {

--- a/tests/lazy_rows.rs
+++ b/tests/lazy_rows.rs
@@ -1,0 +1,1360 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::panic::RefUnwindSafe;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use pretty_assertions::{assert_eq, assert_ne};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::text::Line;
+use ratatui_table::{HighlightSpacing, Row, Table, TableState};
+use ratatui_widgets::block::Block;
+
+/// Build a lazy table through closures that are **not** known to be [`UnwindSafe`].
+///
+/// `Table<'static>: Send + Sync + UnwindSafe + RefUnwindSafe` is already covered by
+/// `ratatui-widgets/tests/auto_traits.rs`, which this must not weaken. What that test cannot see is
+/// how strictly the closures themselves are bounded: `Arc<T>: UnwindSafe` only needs
+/// `T: RefUnwindSafe`, so neither closure needs `UnwindSafe` and callers must not be asked for it.
+///
+/// The assertion lives in this where-clause, which deliberately omits `UnwindSafe`. Tightening
+/// either bound on [`Table::lazy_rows`] or [`Table::row_height_with`] turns that into a compile
+/// error here.
+///
+/// [`UnwindSafe`]: std::panic::UnwindSafe
+fn lazy_table_from_closures<H, F>(row_count: usize, height: H, row: F) -> Table<'static>
+where
+    H: Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'static,
+    F: Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe + 'static,
+{
+    Table::lazy_rows(row_count, [Constraint::Length(10)], row).row_height_with(height)
+}
+
+#[test]
+fn lazy_closures_do_not_require_unwind_safe() {
+    let table = lazy_table_from_closures(2, |_| 1, |index| Row::new([format!("row {index}")]));
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 2);
+
+    assert_content(&buffer, ["row 0       ", "row 1       "]);
+}
+
+fn render_table(table: Table<'_>, state: &mut TableState, width: u16, height: u16) -> Buffer {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            frame.render_stateful_widget(table, frame.area(), state);
+        })
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+fn assert_content<'line, Lines>(buffer: &Buffer, expected: Lines)
+where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let expected_buf = Buffer::with_lines(expected);
+    for (i, (actual, exp)) in buffer
+        .content
+        .iter()
+        .zip(expected_buf.content.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            actual.symbol(),
+            exp.symbol(),
+            "cell {i} symbol mismatch: got {:?}, want {:?}",
+            actual.symbol(),
+            exp.symbol()
+        );
+    }
+}
+
+#[test]
+fn lazy_table_rows_build_only_the_visible_window() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000          ",
+            "row 0001          ",
+            "row 0002          ",
+            "row 0003          ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_start_from_the_state_offset() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_offset(5_000);
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 5000          ",
+            "row 5001          ",
+            "row 5002          ",
+            "row 5003          ",
+        ],
+    );
+    assert_eq!(state.offset(), 5_000);
+    assert_eq!(&*built.lock().unwrap(), &[5_000, 5_001, 5_002, 5_003]);
+}
+
+#[test]
+fn lazy_table_rows_jump_to_a_selected_row_without_building_preceding_rows() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows)
+        .highlight_spacing(HighlightSpacing::Always)
+        .highlight_symbol(">")
+        .row_highlight_style(Style::new().bg(Color::Blue));
+    let mut state = TableState::default().with_selected(5_000);
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            " row 4997         ",
+            " row 4998         ",
+            " row 4999         ",
+            ">row 5000         ",
+        ],
+    );
+    assert_eq!(state.offset(), 4_997);
+    assert_eq!(&*built.lock().unwrap(), &[4_997, 4_998, 4_999, 5_000]);
+}
+
+#[test]
+fn lazy_table_rows_with_fewer_rows_than_viewport_builds_only_those_rows() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // 1000 total rows but viewport holds only 4 — exactly 4 must be built
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "row 0003       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only the 4 visible rows must be built; the remaining 996 must never be touched
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_rows_exactly_fill_viewport() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("item {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(2_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "item 0000      ",
+            "item 0001      ",
+            "item 0002      ",
+            "item 0003      ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_with_multi_line_row_height() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // height=2 means each row occupies 2 lines; 6-line viewport fits 3 rows
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).row_height(2);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "               ",
+            "row 0001       ",
+            "               ",
+            "row 0002       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_table_rows_partial_row_at_bottom_is_included() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // height=3, area_height=5: fits 1 full row + 1 partial row (2 lines of the second row)
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).row_height(3);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 5);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "               ",
+            "               ",
+            "row 0001       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Both row 0 and the partial row 1 must be built
+    assert_eq!(&*built.lock().unwrap(), &[0, 1]);
+}
+
+#[test]
+fn lazy_table_rows_selected_first_row() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_selected(0);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "row 0003       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_selected_last_row_scrolls_to_show_it() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    // Select the very last row; the table must scroll to show it at the bottom
+    let mut state = TableState::default().with_selected(4_999);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 4996       ",
+            "row 4997       ",
+            "row 4998       ",
+            "row 4999       ",
+        ],
+    );
+    assert_eq!(state.offset(), 4_996);
+    assert_eq!(&*built.lock().unwrap(), &[4_996, 4_997, 4_998, 4_999]);
+}
+
+#[test]
+fn lazy_table_rows_offset_beyond_count_is_clamped() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows);
+    // Offset wildly exceeds row count — clamps to last_row (999), only that row is visible
+    let mut state = TableState::default().with_offset(99_999);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0999       ",
+            "               ",
+            "               ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 999, "offset must clamp to last row");
+    let b = built.lock().unwrap();
+    // Only the clamped row is built, not all 1000
+    assert_eq!(&*b, &[999]);
+    drop(b);
+}
+
+#[test]
+fn lazy_table_rows_selection_highlight_style_applied_to_selected_row() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows)
+        .row_highlight_style(Style::new().bg(Color::Red));
+    let mut state = TableState::default().with_selected(1);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "row 0003       ",
+        ],
+    );
+    // The selected row (y=1) must have the red background; others must not
+    let selected_cell = &buffer.content[15]; // row 1, col 0 (width=15)
+    assert_eq!(
+        selected_cell.style().bg,
+        Some(Color::Red),
+        "selected row must have red background"
+    );
+    let unselected_cell = &buffer.content[0]; // row 0, col 0
+    assert_ne!(
+        unselected_cell.style().bg,
+        Some(Color::Red),
+        "unselected row must not have red background"
+    );
+    // Only 4 rows built (not all 5000)
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_highlight_symbol_rendered_for_selected_row() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows)
+        .highlight_spacing(HighlightSpacing::Always)
+        .highlight_symbol(">> ");
+    let mut state = TableState::default().with_selected(2);
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "   row 0000       ",
+            "   row 0001       ",
+            ">> row 0002       ",
+            "   row 0003       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_with_header_does_not_affect_row_indexing() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let header = Row::new(["Header"]);
+    // 4-line viewport: 1 header + 3 data rows visible
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).header(header);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "Header         ",
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only 3 data rows were built despite 5000 total
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_table_rows_with_footer_does_not_affect_row_indexing() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let footer = Row::new(["Footer"]);
+    // 4-line viewport: 3 data rows + 1 footer
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).footer(footer);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "Footer         ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only 3 data rows were built
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_table_rows_with_block_reduces_inner_area() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // 6-line viewport with bordered block: inner area is 4 lines
+    let table =
+        Table::lazy_rows(5_000, [Constraint::Length(8)], rows).block(Block::bordered().title("T"));
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "┌T────────────┐",
+            "│row 0000     │",
+            "│row 0001     │",
+            "│row 0002     │",
+            "│row 0003     │",
+            "└─────────────┘",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only 4 rows built (inner area is 4 lines after borders)
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_mid_list_offset_without_selection() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:05}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_offset(999);
+
+    let buffer = render_table(table, &mut state, 15, 3);
+
+    assert_content(
+        &buffer,
+        ["row 00999      ", "row 01000      ", "row 01001      "],
+    );
+    assert_eq!(state.offset(), 999);
+    assert_eq!(&*built.lock().unwrap(), &[999, 1_000, 1_001]);
+}
+
+#[test]
+fn lazy_table_rows_selection_above_offset_scrolls_back() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    // Offset is at 100 but we select row 50 — must scroll back
+    let mut state = TableState::default().with_offset(100).with_selected(50);
+
+    render_table(table, &mut state, 15, 4);
+
+    assert_eq!(
+        state.offset(),
+        50,
+        "table must scroll back to show selected row"
+    );
+    let b = built.lock().unwrap();
+    assert!(b.contains(&50), "selected row must be built");
+    assert!(
+        b.iter().all(|&i| (50..54).contains(&i)),
+        "only 4 rows near selection should be built"
+    );
+    drop(b);
+}
+
+#[test]
+fn lazy_table_rows_multiple_columns_layout() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("name{index:03}"), format!("val{index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(7), Constraint::Length(7)], rows);
+    let mut state = TableState::default().with_offset(10);
+
+    let buffer = render_table(table, &mut state, 20, 3);
+
+    assert_content(
+        &buffer,
+        [
+            "name010 val0010     ",
+            "name011 val0011     ",
+            "name012 val0012     ",
+        ],
+    );
+    assert_eq!(&*built.lock().unwrap(), &[10, 11, 12]);
+}
+
+#[test]
+fn lazy_table_rows_no_rows_built_for_zero_height_area() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    // Render into a zero-height area — nothing should be built
+    let backend = TestBackend::new(15, 5);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            frame.render_stateful_widget(table, Rect::new(0, 0, 15, 0), &mut state);
+        })
+        .unwrap();
+
+    assert!(
+        built.lock().unwrap().is_empty(),
+        "factory must not be called for a zero-height area"
+    );
+}
+
+#[test]
+fn lazy_table_rows_keep_their_offset_when_the_header_fills_the_area() {
+    // The table area is not empty, but the header leaves no room for rows at all.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).header(Row::new(["head"]));
+    let mut state = TableState::default().with_offset(42);
+
+    let buffer = render_table(table, &mut state, 12, 1);
+
+    assert_content(&buffer, ["head        "]);
+    assert!(
+        built.lock().unwrap().is_empty(),
+        "factory must not be called when no row can be shown"
+    );
+    assert_eq!(
+        state.offset(),
+        42,
+        "an area too small to show a row must not discard the offset"
+    );
+}
+
+#[test]
+fn lazy_table_rows_clamp_their_offset_when_the_header_fills_the_area() {
+    // As above, but the offset is past the end of the table, so it is clamped like it would be if
+    // there were room to draw.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(10, [Constraint::Length(10)], rows).header(Row::new(["head"]));
+    let mut state = TableState::default().with_offset(500);
+
+    let buffer = render_table(table, &mut state, 12, 1);
+
+    assert_content(&buffer, ["head        "]);
+    assert!(built.lock().unwrap().is_empty());
+    assert_eq!(state.offset(), 9, "the offset is clamped to the last row");
+}
+
+#[test]
+fn lazy_table_rows_multiline_scroll_uses_floor_not_ceil() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height(2);
+    let mut state = TableState::default().with_selected(99);
+
+    let buffer = render_table(table, &mut state, 15, 5);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0098       ",
+            "               ",
+            "row 0099       ",
+            "               ",
+            "               ",
+        ],
+    );
+    assert_eq!(
+        state.offset(),
+        98,
+        "offset must be 98 (floor anchor), not 97 (ceil anchor)"
+    );
+    // Exactly rows 98 and 99 built — row 97 must NOT be called
+    assert_eq!(&*built.lock().unwrap(), &[98, 99]);
+}
+
+#[test]
+fn lazy_table_rows_select_last_with_usize_max_clamps_correctly() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
+    // select_last() sets selected to usize::MAX — must clamp to last real row
+    let mut state = TableState::default();
+    state.select_last();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_eq!(
+        state.selected(),
+        Some(99),
+        "usize::MAX selection must clamp to last row"
+    );
+    assert_content(
+        &buffer,
+        [
+            "row 0096       ",
+            "row 0097       ",
+            "row 0098       ",
+            "row 0099       ",
+        ],
+    );
+    // Only 4 rows near end built, not all 100
+    assert_eq!(&*built.lock().unwrap(), &[96, 97, 98, 99]);
+}
+
+#[test]
+fn lazy_table_rows_multiline_rows_with_explicit_offset() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // row_height=2, area=6: 3 full rows visible.  offset=20 means start at row 20.
+    let table = Table::lazy_rows(500, [Constraint::Length(10)], rows).row_height(2);
+    let mut state = TableState::default().with_offset(20);
+
+    let buffer = render_table(table, &mut state, 15, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0020       ",
+            "               ",
+            "row 0021       ",
+            "               ",
+            "row 0022       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 20);
+    // Rows 20, 21, 22 built — the offset is a row index, not a line index
+    assert_eq!(&*built.lock().unwrap(), &[20, 21, 22]);
+}
+
+#[test]
+fn lazy_table_rows_multiline_with_header_and_selection_scroll() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let header = Row::new(["Name"]);
+    let table = Table::lazy_rows(500, [Constraint::Length(10)], rows)
+        .row_height(2)
+        .header(header);
+    let mut state = TableState::default().with_selected(200);
+
+    let buffer = render_table(table, &mut state, 15, 7);
+
+    assert_content(
+        &buffer,
+        [
+            "Name           ",
+            "row 0198       ",
+            "               ",
+            "row 0199       ",
+            "               ",
+            "row 0200       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 198);
+    // Exactly 3 data rows built
+    assert_eq!(&*built.lock().unwrap(), &[198, 199, 200]);
+}
+
+/// A row factory that records, in order, the indexes it was called with.
+fn recording_rows() -> (
+    Arc<Mutex<Vec<usize>>>,
+    impl Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe,
+) {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let factory = {
+        let built = Arc::clone(&built);
+        move |index: usize| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    (built, factory)
+}
+
+/// Rows alternate between two lines (even indexes) and one line (odd indexes).
+const fn alternating_height(index: usize) -> u16 {
+    if index.is_multiple_of(2) { 2 } else { 1 }
+}
+
+#[test]
+fn lazy_variable_rows_are_laid_out_at_their_own_heights() {
+    let (built, rows) = recording_rows();
+    let table =
+        Table::lazy_rows(5, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000    ", // height 2
+            "            ",
+            "row 0001    ", // height 1
+            "row 0002    ", // height 2
+            "            ",
+            "row 0003    ", // height 1
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_variable_rows_start_from_the_state_offset() {
+    let (built, rows) = recording_rows();
+    let table =
+        Table::lazy_rows(1_000, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let mut state = TableState::default().with_offset(10);
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0010    ",
+            "            ",
+            "row 0011    ",
+            "row 0012    ",
+            "            ",
+            "row 0013    ",
+        ],
+    );
+    assert_eq!(state.offset(), 10);
+    assert_eq!(&*built.lock().unwrap(), &[10, 11, 12, 13]);
+}
+
+#[test]
+fn lazy_variable_rows_anchor_a_selection_below_the_window() {
+    let (built, rows) = recording_rows();
+    // Every tenth row is three lines tall, the rest are single lines.
+    let heights = |index: usize| if index.is_multiple_of(10) { 3 } else { 1 };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default().with_selected(99);
+
+    let buffer = render_table(table, &mut state, 12, 5);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0095    ",
+            "row 0096    ",
+            "row 0097    ",
+            "row 0098    ",
+            "row 0099    ",
+        ],
+    );
+    assert_eq!(state.offset(), 95);
+    assert_eq!(&*built.lock().unwrap(), &[95, 96, 97, 98, 99]);
+}
+
+#[test]
+fn lazy_variable_rows_scroll_back_less_for_a_tall_selected_row() {
+    let (built, rows) = recording_rows();
+    // Row 20 is three lines tall, so it leaves room for only one row above it in a 4 line area.
+    let heights = |index: usize| if index == 20 { 3 } else { 1 };
+    let table = Table::lazy_rows(50, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default().with_selected(20);
+
+    let buffer = render_table(table, &mut state, 12, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0019    ",
+            "row 0020    ", // three lines tall
+            "            ",
+            "            ",
+        ],
+    );
+    assert_eq!(state.offset(), 19);
+    assert_eq!(&*built.lock().unwrap(), &[19, 20]);
+}
+
+#[test]
+fn lazy_variable_rows_partial_tall_row_at_the_bottom_is_clipped() {
+    let (built, rows) = recording_rows();
+    // Row 1 is five lines tall but only two lines of space are left for it.
+    let heights = |index: usize| if index == 1 { 5 } else { 1 };
+    let table = Table::lazy_rows(10, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["row 0000    ", "row 0001    ", "            "]);
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1]);
+}
+
+#[test]
+fn lazy_variable_rows_selection_above_offset_scrolls_back() {
+    let (built, rows) = recording_rows();
+    let table =
+        Table::lazy_rows(1_000, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let mut state = TableState::default().with_offset(100).with_selected(50);
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0050    ",
+            "            ",
+            "row 0051    ",
+            "row 0052    ",
+            "            ",
+            "row 0053    ",
+        ],
+    );
+    assert_eq!(state.offset(), 50);
+    assert_eq!(&*built.lock().unwrap(), &[50, 51, 52, 53]);
+}
+
+#[test]
+fn lazy_variable_rows_with_header_use_the_remaining_height() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
+        .row_height_with(alternating_height)
+        .header(Row::new(["Name"]));
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "Name        ",
+            "row 0000    ",
+            "            ",
+            "row 0001    ",
+            "row 0002    ",
+            "            ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_variable_rows_selection_highlight_covers_the_whole_row_height() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
+        .row_height_with(alternating_height)
+        .row_highlight_style(Style::new().bg(Color::Red));
+    // Row 2 is two lines tall and starts on the fourth line (2 + 1 lines above it).
+    let mut state = TableState::default().with_selected(2);
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    for (line, highlighted) in [(0, false), (1, false), (2, false), (3, true), (4, true)] {
+        let cell = &buffer.content[line * 12];
+        assert_eq!(
+            cell.style().bg == Some(Color::Red),
+            highlighted,
+            "line {line} should{} be highlighted",
+            if highlighted { "" } else { " not" }
+        );
+    }
+}
+
+#[test]
+fn lazy_variable_rows_height_closure_is_not_called_for_every_row() {
+    let (built, rows) = recording_rows();
+    let height_calls = Arc::new(AtomicUsize::new(0));
+    let heights = {
+        let height_calls = Arc::clone(&height_calls);
+        move |_index: usize| {
+            height_calls.fetch_add(1, Ordering::Relaxed);
+            1
+        }
+    };
+    let table =
+        Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default().with_selected(999_999);
+
+    render_table(table, &mut state, 12, 4);
+
+    assert_eq!(state.offset(), 999_996);
+    assert_eq!(
+        &*built.lock().unwrap(),
+        &[999_996, 999_997, 999_998, 999_999]
+    );
+    // Scrolling a million rows down must stay proportional to the viewport, not to the distance
+    // scrolled: a handful of height lookups, and nothing like a million of them.
+    let calls = height_calls.load(Ordering::Relaxed);
+    assert!(calls <= 16, "height closure was called {calls} times");
+}
+
+#[test]
+fn lazy_variable_rows_of_zero_height_do_not_build_the_whole_table() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).row_height_with(|_| 0);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 4);
+
+    assert_content(&buffer, ["            "; 4]);
+    // Zero-height rows can never fill the area, so the window is bounded by the area height
+    // instead of running through the whole dataset.
+    let built = built.lock().unwrap();
+    assert!(built.len() <= 5, "built {} rows", built.len());
+    drop(built);
+}
+
+#[test]
+fn lazy_rows_ignore_the_height_and_margins_set_by_the_factory() {
+    let (built, _rows) = recording_rows();
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index: usize| {
+            built.lock().unwrap().push(index);
+            // All of these are ignored: the table's row height is authoritative, because the
+            // scroll calculation never sees the row itself.
+            Row::new([format!("row {index:04}")])
+                .height(3)
+                .top_margin(2)
+                .bottom_margin(2)
+        }
+    };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000    ",
+            "row 0001    ",
+            "row 0002    ",
+            "row 0003    ",
+        ],
+    );
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_rows_are_replaced_by_explicitly_set_rows() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows)
+        .rows([Row::new(["first"]), Row::new(["second"])]);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["first       ", "second      ", "            "]);
+    assert!(
+        built.lock().unwrap().is_empty(),
+        "the lazy factory must not be used once rows are set explicitly"
+    );
+}
+
+#[test]
+fn lazy_rows_column_count_comes_from_the_widths() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(5), Constraint::Length(5)], rows);
+    let mut state = TableState::default();
+    state.select_column(Some(9));
+
+    render_table(table, &mut state, 12, 3);
+
+    assert_eq!(
+        state.selected_column(),
+        Some(1),
+        "column selection must clamp to the number of widths"
+    );
+}
+
+#[test]
+fn lazy_rows_with_no_rows_clear_the_selection() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(0, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_selected(5);
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["            "; 3]);
+    assert_eq!(state.selected(), None);
+    assert!(built.lock().unwrap().is_empty());
+}
+
+#[test]
+fn lazy_tables_are_cloneable_and_comparable() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
+
+    assert_eq!(table.clone(), table, "a clone shares the same row factory");
+    assert!(!format!("{table:?}").is_empty(), "Table stays Debug");
+
+    let (_built, other_rows) = recording_rows();
+    let other = Table::lazy_rows(100, [Constraint::Length(10)], other_rows);
+    assert_ne!(table, other, "different factories are different tables");
+}
+
+#[test]
+fn lazy_tables_with_per_row_heights_are_cloneable_and_comparable() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 2);
+
+    assert_eq!(
+        table.clone(),
+        table,
+        "a clone shares the same height closure"
+    );
+    assert!(
+        !format!("{table:?}").is_empty(),
+        "a table with a height closure stays Debug"
+    );
+
+    let other_heights = table.clone().row_height_with(|_| 2);
+    assert_ne!(
+        table, other_heights,
+        "different height closures are different tables"
+    );
+
+    // Uniform and per-row heights are never equal, whatever they compute.
+    let uniform = table.clone().row_height(2);
+    assert_ne!(
+        table, uniform,
+        "a height closure never equals a uniform height"
+    );
+    assert_ne!(
+        uniform, table,
+        "a uniform height never equals a height closure"
+    );
+}
+
+#[test]
+fn lazy_tables_hash_consistently_with_equality() {
+    let (_built, rows) = recording_rows();
+    let uniform = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height(2);
+    assert_eq!(
+        hash_of(&uniform.clone()),
+        hash_of(&uniform),
+        "equal tables with a uniform height must hash equally"
+    );
+
+    // Cloning shares the row factory, so the height is the only thing left to tell these apart.
+    assert_ne!(
+        hash_of(&uniform.clone().row_height(1)),
+        hash_of(&uniform),
+        "the row height must take part in the hash"
+    );
+
+    let (_built, rows) = recording_rows();
+    let per_row = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 2);
+    assert_eq!(
+        hash_of(&per_row.clone()),
+        hash_of(&per_row),
+        "equal tables with a height closure must hash equally"
+    );
+}
+
+fn hash_of(table: &Table<'_>) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    table.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[test]
+fn lazy_rows_keep_an_oversized_selected_row_visible() {
+    // Rows are three lines tall but the area is only two lines high, so no row ever fits.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 3);
+    let mut state = TableState::default().with_selected(0);
+
+    let buffer = render_table(table, &mut state, 12, 2);
+
+    assert_content(&buffer, ["row 0000    ", "            "]);
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0]);
+
+    // The same holds for a selection further down: the window anchors on it and clips it, rather
+    // than scrolling past it.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 3);
+    let mut state = TableState::default().with_selected(50);
+
+    let buffer = render_table(table, &mut state, 12, 2);
+
+    assert_content(&buffer, ["row 0050    ", "            "]);
+    assert_eq!(state.offset(), 50);
+    assert_eq!(&*built.lock().unwrap(), &[50]);
+}
+
+#[test]
+fn the_last_row_height_setting_wins() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
+        .row_height_with(|_| 3)
+        .row_height(1);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["row 0000    ", "row 0001    ", "row 0002    "]);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn row_height_is_ignored_by_eagerly_built_tables() {
+    let table = Table::new(
+        [Row::new(["first"]), Row::new(["second"])],
+        [Constraint::Length(10)],
+    )
+    .row_height(3);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    // Eager rows carry their own height, so both rows stay one line tall.
+    assert_content(&buffer, ["first       ", "second      ", "            "]);
+}
+
+/// Render the same table lazily and eagerly and assert the two are indistinguishable.
+#[track_caller]
+fn assert_matches_eager_table(
+    row_count: usize,
+    heights: fn(usize) -> u16,
+    area: (u16, u16),
+    offset: usize,
+    selected: Option<usize>,
+) {
+    let row = |index: usize| Row::new([format!("row {index:04}")]);
+    let (width, height) = area;
+
+    if let Some(selected) = selected
+        && heights(selected.min(row_count - 1)) > height
+    {
+        return;
+    }
+
+    let mut lazy_state = TableState::default().with_offset(offset);
+    lazy_state.select(selected);
+    let lazy = Table::lazy_rows(row_count, [Constraint::Length(10)], row).row_height_with(heights);
+    let lazy_buffer = render_table(lazy, &mut lazy_state, width, height);
+
+    let mut eager_state = TableState::default().with_offset(offset);
+    eager_state.select(selected);
+    let eager = Table::new(
+        (0..row_count).map(|index| row(index).height(heights(index))),
+        [Constraint::Length(10)],
+    );
+    let eager_buffer = render_table(eager, &mut eager_state, width, height);
+
+    assert_eq!(
+        lazy_buffer, eager_buffer,
+        "lazy and eager rendering diverged for {row_count} rows in {width}x{height}, \
+         offset {offset}, selected {selected:?}"
+    );
+    assert_eq!(
+        lazy_state.offset(),
+        eager_state.offset(),
+        "lazy and eager offsets diverged for {row_count} rows in {width}x{height}, \
+         offset {offset}, selected {selected:?}"
+    );
+}
+
+#[test]
+fn lazy_rows_render_like_eager_rows_of_uniform_height() {
+    for row_height in [1_u16, 2, 3] {
+        for area_height in 1_u16..=8 {
+            for offset in [0_usize, 1, 7, 40] {
+                for selected in [None, Some(0), Some(1), Some(8), Some(39)] {
+                    assert_matches_eager_table(
+                        40,
+                        match row_height {
+                            1 => |_| 1,
+                            2 => |_| 2,
+                            _ => |_| 3,
+                        },
+                        (12, area_height),
+                        offset,
+                        selected,
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn lazy_rows_render_like_eager_rows_of_varying_height() {
+    for heights in [
+        alternating_height as fn(usize) -> u16,
+        |index| if index.is_multiple_of(3) { 3 } else { 1 },
+        |index| (index % 4) as u16 + 1,
+        |index| if index == 12 { 4 } else { 1 },
+    ] {
+        for area_height in 1_u16..=8 {
+            for offset in [0_usize, 1, 7, 30] {
+                for selected in [None, Some(0), Some(2), Some(12), Some(29)] {
+                    assert_matches_eager_table(30, heights, (12, area_height), offset, selected);
+                }
+            }
+        }
+    }
+}

--- a/tests/lazy_rows.rs
+++ b/tests/lazy_rows.rs
@@ -489,7 +489,7 @@ fn lazy_table_rows_clamp_their_offset_when_the_header_fills_the_area() {
     let buffer = render_table(table, &mut state, 12, 1);
 
     assert_content(&buffer, ["head        "]);
-    assert!(built_indexes(&built).is_empty());
+    assert_eq!(built_indexes(&built), [] as [usize; 0]);
     assert_eq!(state.offset(), 9, "the offset is clamped to the last row");
 }
 
@@ -943,7 +943,7 @@ fn lazy_rows_with_no_rows_clear_the_selection() {
 
     assert_content(&buffer, ["            "; 3]);
     assert_eq!(state.selected(), None);
-    assert!(built_indexes(&built).is_empty());
+    assert_eq!(built_indexes(&built), [] as [usize; 0]);
 }
 
 #[test]

--- a/tests/lazy_rows.rs
+++ b/tests/lazy_rows.rs
@@ -12,6 +12,7 @@ use ratatui::style::{Color, Style};
 use ratatui::text::Line;
 use ratatui_table::{HighlightSpacing, Row, Table, TableState};
 use ratatui_widgets::block::Block;
+use rstest::rstest;
 
 /// Build a lazy table through closures that are **not** known to be [`UnwindSafe`].
 ///
@@ -21,8 +22,8 @@ use ratatui_widgets::block::Block;
 /// `T: RefUnwindSafe`, so neither closure needs `UnwindSafe` and callers must not be asked for it.
 ///
 /// The assertion lives in this where-clause, which deliberately omits `UnwindSafe`. Tightening
-/// either bound on [`Table::lazy_rows`] or [`Table::row_height_with`] turns that into a compile
-/// error here.
+/// either bound on [`Table::lazy_rows`] or [`Table::lazy_row_height_with`] turns that into a
+/// compile error here.
 ///
 /// [`UnwindSafe`]: std::panic::UnwindSafe
 fn lazy_table_from_closures<H, F>(row_count: usize, height: H, row: F) -> Table<'static>
@@ -30,7 +31,7 @@ where
     H: Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'static,
     F: Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe + 'static,
 {
-    Table::lazy_rows(row_count, [Constraint::Length(10)], row).row_height_with(height)
+    Table::lazy_rows(row_count, [Constraint::Length(10)], row).lazy_row_height_with(height)
 }
 
 #[test]
@@ -76,44 +77,39 @@ where
     }
 }
 
-#[test]
-fn lazy_table_rows_build_only_the_visible_window() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
-    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
+/// However many rows a table has, and wherever the selection sits inside the first window, only
+/// the rows the viewport can show are ever built.
+#[rstest]
+#[case::far_more_rows_than_lines(10_000, None)]
+#[case::fewer_rows_than_the_table_claims(1_000, None)]
+#[case::rows_exactly_fill_the_viewport(4, None)]
+#[case::first_row_selected(5_000, Some(0))]
+fn lazy_table_rows_build_only_the_visible_window(
+    #[case] row_count: usize,
+    #[case] selected: Option<usize>,
+) {
+    let (built, table) = recording_table(row_count);
     let mut state = TableState::default();
+    state.select(selected);
 
-    let buffer = render_table(table, &mut state, 18, 4);
+    let buffer = render_table(table, &mut state, 15, 4);
 
     assert_content(
         &buffer,
         [
-            "row 0000          ",
-            "row 0001          ",
-            "row 0002          ",
-            "row 0003          ",
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "row 0003       ",
         ],
     );
     assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+    assert_eq!(built_indexes(&built), [0, 1, 2, 3]);
 }
 
 #[test]
 fn lazy_table_rows_start_from_the_state_offset() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
     let mut state = TableState::default().with_offset(5_000);
 
@@ -129,19 +125,12 @@ fn lazy_table_rows_start_from_the_state_offset() {
         ],
     );
     assert_eq!(state.offset(), 5_000);
-    assert_eq!(&*built.lock().unwrap(), &[5_000, 5_001, 5_002, 5_003]);
+    assert_eq!(built_indexes(&built), [5_000, 5_001, 5_002, 5_003]);
 }
 
 #[test]
 fn lazy_table_rows_jump_to_a_selected_row_without_building_preceding_rows() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows)
         .highlight_spacing(HighlightSpacing::Always)
         .highlight_symbol(">")
@@ -160,79 +149,14 @@ fn lazy_table_rows_jump_to_a_selected_row_without_building_preceding_rows() {
         ],
     );
     assert_eq!(state.offset(), 4_997);
-    assert_eq!(&*built.lock().unwrap(), &[4_997, 4_998, 4_999, 5_000]);
+    assert_eq!(built_indexes(&built), [4_997, 4_998, 4_999, 5_000]);
 }
 
 #[test]
-fn lazy_table_rows_with_fewer_rows_than_viewport_builds_only_those_rows() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
-    // 1000 total rows but viewport holds only 4 — exactly 4 must be built
-    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows);
-    let mut state = TableState::default();
-
-    let buffer = render_table(table, &mut state, 15, 4);
-
-    assert_content(
-        &buffer,
-        [
-            "row 0000       ",
-            "row 0001       ",
-            "row 0002       ",
-            "row 0003       ",
-        ],
-    );
-    assert_eq!(state.offset(), 0);
-    // Only the 4 visible rows must be built; the remaining 996 must never be touched
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
-}
-
-#[test]
-fn lazy_table_rows_rows_exactly_fill_viewport() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("item {index:04}")])
-        }
-    };
-    let table = Table::lazy_rows(2_000, [Constraint::Length(10)], rows);
-    let mut state = TableState::default();
-
-    let buffer = render_table(table, &mut state, 15, 4);
-
-    assert_content(
-        &buffer,
-        [
-            "item 0000      ",
-            "item 0001      ",
-            "item 0002      ",
-            "item 0003      ",
-        ],
-    );
-    assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
-}
-
-#[test]
-fn lazy_table_rows_with_multi_line_row_height() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+fn lazy_table_rows_with_a_multi_line_lazy_row_height() {
+    let (built, rows) = recording_rows();
     // height=2 means each row occupies 2 lines; 6-line viewport fits 3 rows
-    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).row_height(2);
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).lazy_row_height(2);
     let mut state = TableState::default();
 
     let buffer = render_table(table, &mut state, 15, 6);
@@ -249,21 +173,14 @@ fn lazy_table_rows_with_multi_line_row_height() {
         ],
     );
     assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+    assert_eq!(built_indexes(&built), [0, 1, 2]);
 }
 
 #[test]
 fn lazy_table_rows_partial_row_at_bottom_is_included() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     // height=3, area_height=5: fits 1 full row + 1 partial row (2 lines of the second row)
-    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).row_height(3);
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).lazy_row_height(3);
     let mut state = TableState::default();
 
     let buffer = render_table(table, &mut state, 15, 5);
@@ -280,47 +197,12 @@ fn lazy_table_rows_partial_row_at_bottom_is_included() {
     );
     assert_eq!(state.offset(), 0);
     // Both row 0 and the partial row 1 must be built
-    assert_eq!(&*built.lock().unwrap(), &[0, 1]);
-}
-
-#[test]
-fn lazy_table_rows_selected_first_row() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
-    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
-    let mut state = TableState::default().with_selected(0);
-
-    let buffer = render_table(table, &mut state, 15, 4);
-
-    assert_content(
-        &buffer,
-        [
-            "row 0000       ",
-            "row 0001       ",
-            "row 0002       ",
-            "row 0003       ",
-        ],
-    );
-    assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+    assert_eq!(built_indexes(&built), [0, 1]);
 }
 
 #[test]
 fn lazy_table_rows_selected_last_row_scrolls_to_show_it() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
     // Select the very last row; the table must scroll to show it at the bottom
     let mut state = TableState::default().with_selected(4_999);
@@ -337,19 +219,12 @@ fn lazy_table_rows_selected_last_row_scrolls_to_show_it() {
         ],
     );
     assert_eq!(state.offset(), 4_996);
-    assert_eq!(&*built.lock().unwrap(), &[4_996, 4_997, 4_998, 4_999]);
+    assert_eq!(built_indexes(&built), [4_996, 4_997, 4_998, 4_999]);
 }
 
 #[test]
 fn lazy_table_rows_offset_beyond_count_is_clamped() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows);
     // Offset wildly exceeds row count — clamps to last_row (999), only that row is visible
     let mut state = TableState::default().with_offset(99_999);
@@ -366,22 +241,13 @@ fn lazy_table_rows_offset_beyond_count_is_clamped() {
         ],
     );
     assert_eq!(state.offset(), 999, "offset must clamp to last row");
-    let b = built.lock().unwrap();
     // Only the clamped row is built, not all 1000
-    assert_eq!(&*b, &[999]);
-    drop(b);
+    assert_eq!(built_indexes(&built), [999]);
 }
 
 #[test]
 fn lazy_table_rows_selection_highlight_style_applied_to_selected_row() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows)
         .row_highlight_style(Style::new().bg(Color::Red));
     let mut state = TableState::default().with_selected(1);
@@ -411,19 +277,12 @@ fn lazy_table_rows_selection_highlight_style_applied_to_selected_row() {
         "unselected row must not have red background"
     );
     // Only 4 rows built (not all 5000)
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+    assert_eq!(built_indexes(&built), [0, 1, 2, 3]);
 }
 
 #[test]
 fn lazy_table_rows_highlight_symbol_rendered_for_selected_row() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows)
         .highlight_spacing(HighlightSpacing::Always)
         .highlight_symbol(">> ");
@@ -441,19 +300,12 @@ fn lazy_table_rows_highlight_symbol_rendered_for_selected_row() {
         ],
     );
     assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+    assert_eq!(built_indexes(&built), [0, 1, 2, 3]);
 }
 
 #[test]
 fn lazy_table_rows_with_header_does_not_affect_row_indexing() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let header = Row::new(["Header"]);
     // 4-line viewport: 1 header + 3 data rows visible
     let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).header(header);
@@ -472,19 +324,12 @@ fn lazy_table_rows_with_header_does_not_affect_row_indexing() {
     );
     assert_eq!(state.offset(), 0);
     // Only 3 data rows were built despite 5000 total
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+    assert_eq!(built_indexes(&built), [0, 1, 2]);
 }
 
 #[test]
 fn lazy_table_rows_with_footer_does_not_affect_row_indexing() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let footer = Row::new(["Footer"]);
     // 4-line viewport: 3 data rows + 1 footer
     let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).footer(footer);
@@ -503,19 +348,12 @@ fn lazy_table_rows_with_footer_does_not_affect_row_indexing() {
     );
     assert_eq!(state.offset(), 0);
     // Only 3 data rows were built
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+    assert_eq!(built_indexes(&built), [0, 1, 2]);
 }
 
 #[test]
 fn lazy_table_rows_with_block_reduces_inner_area() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     // 6-line viewport with bordered block: inner area is 4 lines
     let table =
         Table::lazy_rows(5_000, [Constraint::Length(8)], rows).block(Block::bordered().title("T"));
@@ -536,19 +374,12 @@ fn lazy_table_rows_with_block_reduces_inner_area() {
     );
     assert_eq!(state.offset(), 0);
     // Only 4 rows built (inner area is 4 lines after borders)
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+    assert_eq!(built_indexes(&built), [0, 1, 2, 3]);
 }
 
 #[test]
 fn lazy_table_rows_mid_list_offset_without_selection() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:05}")])
-        }
-    };
+    let (built, rows) = recording_rows_with(|index| Row::new([format!("row {index:05}")]));
     let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
     let mut state = TableState::default().with_offset(999);
 
@@ -559,19 +390,12 @@ fn lazy_table_rows_mid_list_offset_without_selection() {
         ["row 00999      ", "row 01000      ", "row 01001      "],
     );
     assert_eq!(state.offset(), 999);
-    assert_eq!(&*built.lock().unwrap(), &[999, 1_000, 1_001]);
+    assert_eq!(built_indexes(&built), [999, 1_000, 1_001]);
 }
 
 #[test]
 fn lazy_table_rows_selection_above_offset_scrolls_back() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
     // Offset is at 100 but we select row 50 — must scroll back
     let mut state = TableState::default().with_offset(100).with_selected(50);
@@ -583,25 +407,19 @@ fn lazy_table_rows_selection_above_offset_scrolls_back() {
         50,
         "table must scroll back to show selected row"
     );
-    let b = built.lock().unwrap();
+    let b = built_indexes(&built);
     assert!(b.contains(&50), "selected row must be built");
     assert!(
         b.iter().all(|&i| (50..54).contains(&i)),
         "only 4 rows near selection should be built"
     );
-    drop(b);
 }
 
 #[test]
 fn lazy_table_rows_multiple_columns_layout() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("name{index:03}"), format!("val{index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows_with(|index| {
+        Row::new([format!("name{index:03}"), format!("val{index:04}")])
+    });
     let table = Table::lazy_rows(5_000, [Constraint::Length(7), Constraint::Length(7)], rows);
     let mut state = TableState::default().with_offset(10);
 
@@ -615,19 +433,12 @@ fn lazy_table_rows_multiple_columns_layout() {
             "name012 val0012     ",
         ],
     );
-    assert_eq!(&*built.lock().unwrap(), &[10, 11, 12]);
+    assert_eq!(built_indexes(&built), [10, 11, 12]);
 }
 
 #[test]
 fn lazy_table_rows_no_rows_built_for_zero_height_area() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index}")])
-        }
-    };
+    let (built, rows) = recording_rows_with(|index| Row::new([format!("row {index}")]));
     let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
     let mut state = TableState::default();
 
@@ -641,7 +452,7 @@ fn lazy_table_rows_no_rows_built_for_zero_height_area() {
         .unwrap();
 
     assert!(
-        built.lock().unwrap().is_empty(),
+        built_indexes(&built).is_empty(),
         "factory must not be called for a zero-height area"
     );
 }
@@ -657,7 +468,7 @@ fn lazy_table_rows_keep_their_offset_when_the_header_fills_the_area() {
 
     assert_content(&buffer, ["head        "]);
     assert!(
-        built.lock().unwrap().is_empty(),
+        built_indexes(&built).is_empty(),
         "factory must not be called when no row can be shown"
     );
     assert_eq!(
@@ -678,21 +489,14 @@ fn lazy_table_rows_clamp_their_offset_when_the_header_fills_the_area() {
     let buffer = render_table(table, &mut state, 12, 1);
 
     assert_content(&buffer, ["head        "]);
-    assert!(built.lock().unwrap().is_empty());
+    assert!(built_indexes(&built).is_empty());
     assert_eq!(state.offset(), 9, "the offset is clamped to the last row");
 }
 
 #[test]
 fn lazy_table_rows_multiline_scroll_uses_floor_not_ceil() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
-    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height(2);
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).lazy_row_height(2);
     let mut state = TableState::default().with_selected(99);
 
     let buffer = render_table(table, &mut state, 15, 5);
@@ -713,19 +517,12 @@ fn lazy_table_rows_multiline_scroll_uses_floor_not_ceil() {
         "offset must be 98 (floor anchor), not 97 (ceil anchor)"
     );
     // Exactly rows 98 and 99 built — row 97 must NOT be called
-    assert_eq!(&*built.lock().unwrap(), &[98, 99]);
+    assert_eq!(built_indexes(&built), [98, 99]);
 }
 
 #[test]
 fn lazy_table_rows_select_last_with_usize_max_clamps_correctly() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
     // select_last() sets selected to usize::MAX — must clamp to last real row
     let mut state = TableState::default();
@@ -748,21 +545,14 @@ fn lazy_table_rows_select_last_with_usize_max_clamps_correctly() {
         ],
     );
     // Only 4 rows near end built, not all 100
-    assert_eq!(&*built.lock().unwrap(), &[96, 97, 98, 99]);
+    assert_eq!(built_indexes(&built), [96, 97, 98, 99]);
 }
 
 #[test]
 fn lazy_table_rows_multiline_rows_with_explicit_offset() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
-    // row_height=2, area=6: 3 full rows visible.  offset=20 means start at row 20.
-    let table = Table::lazy_rows(500, [Constraint::Length(10)], rows).row_height(2);
+    let (built, rows) = recording_rows();
+    // lazy_row_height=2, area=6: 3 full rows visible.  offset=20 means start at row 20.
+    let table = Table::lazy_rows(500, [Constraint::Length(10)], rows).lazy_row_height(2);
     let mut state = TableState::default().with_offset(20);
 
     let buffer = render_table(table, &mut state, 15, 6);
@@ -780,22 +570,15 @@ fn lazy_table_rows_multiline_rows_with_explicit_offset() {
     );
     assert_eq!(state.offset(), 20);
     // Rows 20, 21, 22 built — the offset is a row index, not a line index
-    assert_eq!(&*built.lock().unwrap(), &[20, 21, 22]);
+    assert_eq!(built_indexes(&built), [20, 21, 22]);
 }
 
 #[test]
 fn lazy_table_rows_multiline_with_header_and_selection_scroll() {
-    let built = Arc::new(Mutex::new(Vec::new()));
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index| {
-            built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
-        }
-    };
+    let (built, rows) = recording_rows();
     let header = Row::new(["Name"]);
     let table = Table::lazy_rows(500, [Constraint::Length(10)], rows)
-        .row_height(2)
+        .lazy_row_height(2)
         .header(header);
     let mut state = TableState::default().with_selected(200);
 
@@ -815,23 +598,53 @@ fn lazy_table_rows_multiline_with_header_and_selection_scroll() {
     );
     assert_eq!(state.offset(), 198);
     // Exactly 3 data rows built
-    assert_eq!(&*built.lock().unwrap(), &[198, 199, 200]);
+    assert_eq!(built_indexes(&built), [198, 199, 200]);
 }
+
+/// The row indexes a factory was called with, in order.
+type Built = Arc<Mutex<Vec<usize>>>;
 
 /// A row factory that records, in order, the indexes it was called with.
 fn recording_rows() -> (
-    Arc<Mutex<Vec<usize>>>,
+    Built,
     impl Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe,
 ) {
+    recording_rows_with(|index| Row::new([format!("row {index:04}")]))
+}
+
+/// As [`recording_rows`], for the tests that need rows of their own shape.
+fn recording_rows_with<F>(
+    row: F,
+) -> (
+    Built,
+    impl Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe,
+)
+where
+    F: Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe + 'static,
+{
     let built = Arc::new(Mutex::new(Vec::new()));
     let factory = {
         let built = Arc::clone(&built);
         move |index: usize| {
             built.lock().unwrap().push(index);
-            Row::new([format!("row {index:04}")])
+            row(index)
         }
     };
     (built, factory)
+}
+
+/// A single column of recorded rows, which is what most of these tests render.
+fn recording_table(row_count: usize) -> (Built, Table<'static>) {
+    let (built, rows) = recording_rows();
+    (
+        built,
+        Table::lazy_rows(row_count, [Constraint::Length(10)], rows),
+    )
+}
+
+/// The indexes built so far, in the order the factory was called with them.
+fn built_indexes(built: &Built) -> Vec<usize> {
+    built.lock().unwrap().clone()
 }
 
 /// Rows alternate between two lines (even indexes) and one line (odd indexes).
@@ -842,8 +655,8 @@ const fn alternating_height(index: usize) -> u16 {
 #[test]
 fn lazy_variable_rows_are_laid_out_at_their_own_heights() {
     let (built, rows) = recording_rows();
-    let table =
-        Table::lazy_rows(5, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let table = Table::lazy_rows(5, [Constraint::Length(10)], rows)
+        .lazy_row_height_with(alternating_height);
     let mut state = TableState::default();
 
     let buffer = render_table(table, &mut state, 12, 6);
@@ -860,14 +673,14 @@ fn lazy_variable_rows_are_laid_out_at_their_own_heights() {
         ],
     );
     assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+    assert_eq!(built_indexes(&built), [0, 1, 2, 3]);
 }
 
 #[test]
 fn lazy_variable_rows_start_from_the_state_offset() {
     let (built, rows) = recording_rows();
-    let table =
-        Table::lazy_rows(1_000, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows)
+        .lazy_row_height_with(alternating_height);
     let mut state = TableState::default().with_offset(10);
 
     let buffer = render_table(table, &mut state, 12, 6);
@@ -884,7 +697,7 @@ fn lazy_variable_rows_start_from_the_state_offset() {
         ],
     );
     assert_eq!(state.offset(), 10);
-    assert_eq!(&*built.lock().unwrap(), &[10, 11, 12, 13]);
+    assert_eq!(built_indexes(&built), [10, 11, 12, 13]);
 }
 
 #[test]
@@ -892,7 +705,7 @@ fn lazy_variable_rows_anchor_a_selection_below_the_window() {
     let (built, rows) = recording_rows();
     // Every tenth row is three lines tall, the rest are single lines.
     let heights = |index: usize| if index.is_multiple_of(10) { 3 } else { 1 };
-    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(heights);
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).lazy_row_height_with(heights);
     let mut state = TableState::default().with_selected(99);
 
     let buffer = render_table(table, &mut state, 12, 5);
@@ -908,7 +721,7 @@ fn lazy_variable_rows_anchor_a_selection_below_the_window() {
         ],
     );
     assert_eq!(state.offset(), 95);
-    assert_eq!(&*built.lock().unwrap(), &[95, 96, 97, 98, 99]);
+    assert_eq!(built_indexes(&built), [95, 96, 97, 98, 99]);
 }
 
 #[test]
@@ -916,7 +729,7 @@ fn lazy_variable_rows_scroll_back_less_for_a_tall_selected_row() {
     let (built, rows) = recording_rows();
     // Row 20 is three lines tall, so it leaves room for only one row above it in a 4 line area.
     let heights = |index: usize| if index == 20 { 3 } else { 1 };
-    let table = Table::lazy_rows(50, [Constraint::Length(10)], rows).row_height_with(heights);
+    let table = Table::lazy_rows(50, [Constraint::Length(10)], rows).lazy_row_height_with(heights);
     let mut state = TableState::default().with_selected(20);
 
     let buffer = render_table(table, &mut state, 12, 4);
@@ -931,7 +744,7 @@ fn lazy_variable_rows_scroll_back_less_for_a_tall_selected_row() {
         ],
     );
     assert_eq!(state.offset(), 19);
-    assert_eq!(&*built.lock().unwrap(), &[19, 20]);
+    assert_eq!(built_indexes(&built), [19, 20]);
 }
 
 #[test]
@@ -939,21 +752,21 @@ fn lazy_variable_rows_partial_tall_row_at_the_bottom_is_clipped() {
     let (built, rows) = recording_rows();
     // Row 1 is five lines tall but only two lines of space are left for it.
     let heights = |index: usize| if index == 1 { 5 } else { 1 };
-    let table = Table::lazy_rows(10, [Constraint::Length(10)], rows).row_height_with(heights);
+    let table = Table::lazy_rows(10, [Constraint::Length(10)], rows).lazy_row_height_with(heights);
     let mut state = TableState::default();
 
     let buffer = render_table(table, &mut state, 12, 3);
 
     assert_content(&buffer, ["row 0000    ", "row 0001    ", "            "]);
     assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1]);
+    assert_eq!(built_indexes(&built), [0, 1]);
 }
 
 #[test]
 fn lazy_variable_rows_selection_above_offset_scrolls_back() {
     let (built, rows) = recording_rows();
-    let table =
-        Table::lazy_rows(1_000, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows)
+        .lazy_row_height_with(alternating_height);
     let mut state = TableState::default().with_offset(100).with_selected(50);
 
     let buffer = render_table(table, &mut state, 12, 6);
@@ -970,14 +783,14 @@ fn lazy_variable_rows_selection_above_offset_scrolls_back() {
         ],
     );
     assert_eq!(state.offset(), 50);
-    assert_eq!(&*built.lock().unwrap(), &[50, 51, 52, 53]);
+    assert_eq!(built_indexes(&built), [50, 51, 52, 53]);
 }
 
 #[test]
 fn lazy_variable_rows_with_header_use_the_remaining_height() {
     let (built, rows) = recording_rows();
     let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
-        .row_height_with(alternating_height)
+        .lazy_row_height_with(alternating_height)
         .header(Row::new(["Name"]));
     let mut state = TableState::default();
 
@@ -995,14 +808,14 @@ fn lazy_variable_rows_with_header_use_the_remaining_height() {
         ],
     );
     assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+    assert_eq!(built_indexes(&built), [0, 1, 2]);
 }
 
 #[test]
 fn lazy_variable_rows_selection_highlight_covers_the_whole_row_height() {
     let (_built, rows) = recording_rows();
     let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
-        .row_height_with(alternating_height)
+        .lazy_row_height_with(alternating_height)
         .row_highlight_style(Style::new().bg(Color::Red));
     // Row 2 is two lines tall and starts on the fourth line (2 + 1 lines above it).
     let mut state = TableState::default().with_selected(2);
@@ -1032,16 +845,13 @@ fn lazy_variable_rows_height_closure_is_not_called_for_every_row() {
         }
     };
     let table =
-        Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).row_height_with(heights);
+        Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).lazy_row_height_with(heights);
     let mut state = TableState::default().with_selected(999_999);
 
     render_table(table, &mut state, 12, 4);
 
     assert_eq!(state.offset(), 999_996);
-    assert_eq!(
-        &*built.lock().unwrap(),
-        &[999_996, 999_997, 999_998, 999_999]
-    );
+    assert_eq!(built_indexes(&built), [999_996, 999_997, 999_998, 999_999]);
     // Scrolling a million rows down must stay proportional to the viewport, not to the distance
     // scrolled: a handful of height lookups, and nothing like a million of them.
     let calls = height_calls.load(Ordering::Relaxed);
@@ -1051,7 +861,8 @@ fn lazy_variable_rows_height_closure_is_not_called_for_every_row() {
 #[test]
 fn lazy_variable_rows_of_zero_height_do_not_build_the_whole_table() {
     let (built, rows) = recording_rows();
-    let table = Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).row_height_with(|_| 0);
+    let table =
+        Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).lazy_row_height_with(|_| 0);
     let mut state = TableState::default();
 
     let buffer = render_table(table, &mut state, 12, 4);
@@ -1059,26 +870,20 @@ fn lazy_variable_rows_of_zero_height_do_not_build_the_whole_table() {
     assert_content(&buffer, ["            "; 4]);
     // Zero-height rows can never fill the area, so the window is bounded by the area height
     // instead of running through the whole dataset.
-    let built = built.lock().unwrap();
+    let built = built_indexes(&built);
     assert!(built.len() <= 5, "built {} rows", built.len());
-    drop(built);
 }
 
 #[test]
 fn lazy_rows_ignore_the_height_and_margins_set_by_the_factory() {
-    let (built, _rows) = recording_rows();
-    let rows = {
-        let built = Arc::clone(&built);
-        move |index: usize| {
-            built.lock().unwrap().push(index);
-            // All of these are ignored: the table's row height is authoritative, because the
-            // scroll calculation never sees the row itself.
-            Row::new([format!("row {index:04}")])
-                .height(3)
-                .top_margin(2)
-                .bottom_margin(2)
-        }
-    };
+    // The height and margins below are all ignored: the table's row height is authoritative,
+    // because the scroll calculation never sees the row itself.
+    let (built, rows) = recording_rows_with(|index| {
+        Row::new([format!("row {index:04}")])
+            .height(3)
+            .top_margin(2)
+            .bottom_margin(2)
+    });
     let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
     let mut state = TableState::default();
 
@@ -1093,7 +898,7 @@ fn lazy_rows_ignore_the_height_and_margins_set_by_the_factory() {
             "row 0003    ",
         ],
     );
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+    assert_eq!(built_indexes(&built), [0, 1, 2, 3]);
 }
 
 #[test]
@@ -1107,7 +912,7 @@ fn lazy_rows_are_replaced_by_explicitly_set_rows() {
 
     assert_content(&buffer, ["first       ", "second      ", "            "]);
     assert!(
-        built.lock().unwrap().is_empty(),
+        built_indexes(&built).is_empty(),
         "the lazy factory must not be used once rows are set explicitly"
     );
 }
@@ -1138,7 +943,7 @@ fn lazy_rows_with_no_rows_clear_the_selection() {
 
     assert_content(&buffer, ["            "; 3]);
     assert_eq!(state.selected(), None);
-    assert!(built.lock().unwrap().is_empty());
+    assert!(built_indexes(&built).is_empty());
 }
 
 #[test]
@@ -1157,7 +962,7 @@ fn lazy_tables_are_cloneable_and_comparable() {
 #[test]
 fn lazy_tables_with_per_row_heights_are_cloneable_and_comparable() {
     let (_built, rows) = recording_rows();
-    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 2);
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).lazy_row_height_with(|_| 2);
 
     assert_eq!(
         table.clone(),
@@ -1169,14 +974,14 @@ fn lazy_tables_with_per_row_heights_are_cloneable_and_comparable() {
         "a table with a height closure stays Debug"
     );
 
-    let other_heights = table.clone().row_height_with(|_| 2);
+    let other_heights = table.clone().lazy_row_height_with(|_| 2);
     assert_ne!(
         table, other_heights,
         "different height closures are different tables"
     );
 
     // Uniform and per-row heights are never equal, whatever they compute.
-    let uniform = table.clone().row_height(2);
+    let uniform = table.clone().lazy_row_height(2);
     assert_ne!(
         table, uniform,
         "a height closure never equals a uniform height"
@@ -1190,7 +995,7 @@ fn lazy_tables_with_per_row_heights_are_cloneable_and_comparable() {
 #[test]
 fn lazy_tables_hash_consistently_with_equality() {
     let (_built, rows) = recording_rows();
-    let uniform = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height(2);
+    let uniform = Table::lazy_rows(100, [Constraint::Length(10)], rows).lazy_row_height(2);
     assert_eq!(
         hash_of(&uniform.clone()),
         hash_of(&uniform),
@@ -1199,13 +1004,13 @@ fn lazy_tables_hash_consistently_with_equality() {
 
     // Cloning shares the row factory, so the height is the only thing left to tell these apart.
     assert_ne!(
-        hash_of(&uniform.clone().row_height(1)),
+        hash_of(&uniform.clone().lazy_row_height(1)),
         hash_of(&uniform),
         "the row height must take part in the hash"
     );
 
     let (_built, rows) = recording_rows();
-    let per_row = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 2);
+    let per_row = Table::lazy_rows(100, [Constraint::Length(10)], rows).lazy_row_height_with(|_| 2);
     assert_eq!(
         hash_of(&per_row.clone()),
         hash_of(&per_row),
@@ -1223,49 +1028,49 @@ fn hash_of(table: &Table<'_>) -> u64 {
 fn lazy_rows_keep_an_oversized_selected_row_visible() {
     // Rows are three lines tall but the area is only two lines high, so no row ever fits.
     let (built, rows) = recording_rows();
-    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 3);
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).lazy_row_height_with(|_| 3);
     let mut state = TableState::default().with_selected(0);
 
     let buffer = render_table(table, &mut state, 12, 2);
 
     assert_content(&buffer, ["row 0000    ", "            "]);
     assert_eq!(state.offset(), 0);
-    assert_eq!(&*built.lock().unwrap(), &[0]);
+    assert_eq!(built_indexes(&built), [0]);
 
     // The same holds for a selection further down: the window anchors on it and clips it, rather
     // than scrolling past it.
     let (built, rows) = recording_rows();
-    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 3);
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).lazy_row_height_with(|_| 3);
     let mut state = TableState::default().with_selected(50);
 
     let buffer = render_table(table, &mut state, 12, 2);
 
     assert_content(&buffer, ["row 0050    ", "            "]);
     assert_eq!(state.offset(), 50);
-    assert_eq!(&*built.lock().unwrap(), &[50]);
+    assert_eq!(built_indexes(&built), [50]);
 }
 
 #[test]
-fn the_last_row_height_setting_wins() {
+fn the_last_lazy_row_height_setting_wins() {
     let (built, rows) = recording_rows();
     let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
-        .row_height_with(|_| 3)
-        .row_height(1);
+        .lazy_row_height_with(|_| 3)
+        .lazy_row_height(1);
     let mut state = TableState::default();
 
     let buffer = render_table(table, &mut state, 12, 3);
 
     assert_content(&buffer, ["row 0000    ", "row 0001    ", "row 0002    "]);
-    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+    assert_eq!(built_indexes(&built), [0, 1, 2]);
 }
 
 #[test]
-fn row_height_is_ignored_by_eagerly_built_tables() {
+fn lazy_row_height_is_ignored_by_eagerly_built_tables() {
     let table = Table::new(
         [Row::new(["first"]), Row::new(["second"])],
         [Constraint::Length(10)],
     )
-    .row_height(3);
+    .lazy_row_height(3);
     let mut state = TableState::default();
 
     let buffer = render_table(table, &mut state, 12, 3);
@@ -1286,6 +1091,9 @@ fn assert_matches_eager_table(
     let row = |index: usize| Row::new([format!("row {index:04}")]);
     let (width, height) = area;
 
+    // The one case where the two deliberately differ: a selected row taller than the whole area.
+    // Eager rows scroll past such a row and leave it off screen, lazy rows anchor the window on it
+    // and clip it. `lazy_rows_keep_an_oversized_selected_row_visible` pins the lazy behaviour.
     if let Some(selected) = selected
         && heights(selected.min(row_count - 1)) > height
     {
@@ -1294,7 +1102,8 @@ fn assert_matches_eager_table(
 
     let mut lazy_state = TableState::default().with_offset(offset);
     lazy_state.select(selected);
-    let lazy = Table::lazy_rows(row_count, [Constraint::Length(10)], row).row_height_with(heights);
+    let lazy =
+        Table::lazy_rows(row_count, [Constraint::Length(10)], row).lazy_row_height_with(heights);
     let lazy_buffer = render_table(lazy, &mut lazy_state, width, height);
 
     let mut eager_state = TableState::default().with_offset(offset);


### PR DESCRIPTION
Closes ratatui/ratatui-table#5

## What

Adds `Table::lazy_rows`, which builds rows on demand instead of collecting them into a `Vec` up front, so a table over a very large dataset costs the viewport rather than the dataset.

```rust
let table = Table::lazy_rows(10_000_000, widths, |index| Row::new([format!("item {index}")]))
    .row_height_with(|index| if index % 25 == 0 { 3 } else { 1 });
```

- `Table::lazy_rows(row_count, widths, factory)` — rows are one line tall by default.
- `Table::row_height(u16)` — uniform height override.
- `Table::row_height_with(impl Fn(usize) -> u16)` — per-row heights.

All three are additive; no existing API changes behaviour.

## Why heights are declared separately

The scroll pass needs the height of rows it will not draw — for instance to work out where the window starts when the selection is below the viewport. For an eager table that is free, because `visible_rows` can index `self.rows`. For a lazy table, asking a row for its height means building it, which is the cost the feature exists to avoid. Declaring heights separately keeps the whole frame proportional to the viewport, and matches how other virtualised lists work (Qt `sizeHintForRow`, UIKit `heightForRowAt`, react-window `itemSize`).

Consequence, documented on the constructor: for lazy rows the declared height is authoritative and `Row::height` / `Row::top_margin` / `Row::bottom_margin` on the returned row are ignored.

## Consistency with existing code

`LazyRowHeights` follows the same shape as `Effect` in `block/shadow.rs`: an enum with cheap built-in variants plus one `Arc<dyn …>` variant, with hand-written `PartialEq` (`Arc::ptr_eq`), `Eq` and `Hash` (`ptr::hash`) so the widget keeps its derives.

It differs in one respect: `CellEffect` requires `Send + Sync + UnwindSafe + RefUnwindSafe`, whereas the lazy closures require only `Send + Sync + RefUnwindSafe`. `Arc<T>: UnwindSafe` needs just `T: RefUnwindSafe`, so the extra bound would restrict callers without buying anything — `Table<'static>` remains `UnwindSafe`, as `ratatui-widgets/tests/auto_traits.rs` already asserts. Happy to add `UnwindSafe` for symmetry if you would rather the two APIs read the same.

## Please look closely at

1. **`LazyRowProvider::visible_rows`** mirrors `Table::visible_rows` step for step, but grows the window upward from the selection instead of scrolling down one row at a time. Two tests assert the two produce identical buffers and offsets across a matrix of row heights, area heights, offsets and selections.
2. **One deliberate divergence**: when the selected row is taller than the whole area, the eager algorithm shrinks `start` past the selection and draws the row *below* it, leaving the selected row off screen. The lazy path keeps it anchored and clips it. I left the eager behaviour alone and documented the difference — happy to open a separate fix if you agree it is a bug.
3. **`row_height` / `row_height_with` are no-ops on eager tables**, since `Table::new` rows carry their own `Row::height`. Documented on both methods and covered by a test. Open to a better name or shape here.

## Testing

- New `tests/lazy_rows.rs`: laziness (asserting the exact set of rows built), offsets, selection anchoring, partial rows, headers/footers/blocks, highlight styles, zero-height rows, clone/eq/hash, and equivalence with `Table::new`.
- `just check-all` passes locally.

## AI assistance
This uses AI for comments and logic validation.
