### PR TITLE
feat(table): select rows, columns, and cells with TableSelection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+
+# vhs recordings
+*.gif
+*.mp4
+*.webm
+*.ascii

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,10 +33,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -42,10 +84,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "castaway"
@@ -63,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +144,77 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -112,16 +252,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "either"
@@ -136,10 +323,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -190,6 +435,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +500,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ident_case"
@@ -286,6 +570,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,8 +588,20 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror",
+ "thiserror 2.0.19",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -314,8 +621,35 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
@@ -327,16 +661,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "num-traits"
@@ -354,6 +765,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -378,6 +804,123 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pest"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -436,6 +979,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,7 +1013,12 @@ checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
@@ -452,8 +1027,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "compact_str",
+ "critical-section",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
@@ -461,10 +1037,32 @@ dependencies = [
  "palette",
  "serde",
  "strum",
- "thiserror",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
 ]
 
 [[package]]
@@ -483,12 +1081,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
 name = "ratatui-widgets"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -500,6 +1119,15 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -576,6 +1204,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +1227,20 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "selection"
+version = "0.0.0"
+dependencies = [
+ "ratatui",
+ "ratatui-table",
+]
 
 [[package]]
 name = "semver"
@@ -637,10 +1292,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "static_assertions"
@@ -677,6 +1386,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -698,12 +1418,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.1",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -769,6 +1585,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +1626,208 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +1835,12 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-table"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "itertools 0.15.0",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["examples/apps/*"]
+
 [package]
 name = "ratatui-table"
 version = "0.2.0"
@@ -11,7 +14,7 @@ edition = "2024"
 rust-version = "1.88.0"
 keywords = ["ratatui", "table", "terminal", "tui", "widget"]
 categories = ["command-line-interface", "gui"]
-exclude = [".github", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md"]
+exclude = [".github", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", "examples"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -41,11 +44,14 @@ ratatui = { version = "0.30.2", default-features = false }
 rstest = "0.26"
 serde_json = "1"
 
-[lints.rust]
+[lints]
+workspace = true
+
+[workspace.lints.rust]
 unsafe_code = "forbid"
 unused = { level = "warn", priority = -1 }
 
-[lints.clippy]
+[workspace.lints.clippy]
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
 cast_precision_loss = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-table"
-version = "0.1.0"
+version = "0.2.0"
 description = "An experimental evolution of Ratatui's built-in Table widget"
 documentation = "https://docs.rs/ratatui-table"
 repository = "https://github.com/ratatui/ratatui-table"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ contributors room to explore borders, virtualization, selection, marking, borrow
 other changes independently.
 
 [`3d8639c`]: https://github.com/ratatui/ratatui/commit/3d8639cbb2f910200f30e680a8923ccaf99ba1bf
+[`Table`]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.Table.html
 
 This crate is an opt-in development path for the built-in widget, not a competing Table design.
 If the experiment succeeds, Ratatui should be able to offer an easy upgrade or re-export path.
@@ -43,16 +44,25 @@ let table = Table::new(rows, widths);
 
 ## Ratatui compatibility
 
-[`Table::block`] accepts [`ratatui_widgets::block::Block`] to preserve the built-in API. This
-means the initial crate depends on `ratatui-widgets` with default features disabled. A future
-Ratatui facade can re-export this crate without requiring this crate to become part of
-`ratatui-widgets` itself.
+[`Table::block`][block] accepts a ratatui-widgets [`Block`][block-widget] to preserve the
+built-in API. This means the initial crate depends on `ratatui-widgets` with default features
+disabled. A future Ratatui facade can re-export this crate without requiring this crate to
+become part of `ratatui-widgets` itself.
+
+[block]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.Table.html#method.block
+[block-widget]: https://docs.rs/ratatui-widgets/latest/ratatui_widgets/block/struct.Block.html
 
 ## Feature flags
 
 - `std` enables the standard-library features of the Ratatui dependencies. The Table itself
   remains usable with `no_std` plus `alloc` by default.
-- `serde` adds serialization and deserialization for [`TableState`] and [`HighlightSpacing`].
+- `serde` adds serialization and deserialization for [`TableState`], [`TableSelection`],
+  [`HighlightSpacing`][hs], and [`HighlightPlacement`][hp].
+
+[`TableState`]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.TableState.html
+[`TableSelection`]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.TableSelection.html
+[hs]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.HighlightSpacing.html
+[hp]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.HighlightPlacement.html
 
 ## Governance
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Examples
+
+Each example is its own crate under `apps/`, so it can pull in whatever dependencies it needs
+without those reaching the library's own dependency tree.
+
+```shell
+cargo run -p selection
+```
+
+| example | what it shows |
+| --- | --- |
+| [selection](apps/selection) | row, column, and cell selection, and where the highlight symbol goes |
+
+These are built against the working tree, not the released crate, so they may use APIs that are
+not published yet.
+
+## Recordings
+
+The tapes in `vhs/` drive the examples for the GIFs in the README and in pull requests. Install
+[VHS], then run one from the repository root:
+
+```shell
+just record selection
+```
+
+The recipe builds the example first and writes `target/<example>.gif`, which is ignored along with
+every other recording. It is deliberately not part of `just check-all`, since VHS is an extra tool
+to install and a recording takes about a minute.
+
+[VHS]: https://github.com/charmbracelet/vhs

--- a/examples/apps/selection/Cargo.toml
+++ b/examples/apps/selection/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "selection"
+description = "Row, column, and cell selection with ratatui-table"
+edition = "2024"
+rust-version = "1.88.0"
+license = "MIT"
+publish = false
+
+[dependencies]
+ratatui = "0.30.2"
+ratatui-table = { path = "../../.." }
+
+[lints]
+workspace = true

--- a/examples/apps/selection/README.md
+++ b/examples/apps/selection/README.md
@@ -1,0 +1,23 @@
+# Selection demo
+
+Row, column, and cell selection, the highlight style of each axis, and the two settings that
+decide where the highlight symbol gets its space.
+
+```shell
+cargo run -p selection
+```
+
+| key | effect |
+| --- | --- |
+| `↑` `↓` / `k` `j` | move the row selection |
+| `←` `→` / `h` `l` | move the column selection |
+| `r` `c` `x` `n` | select a row, a column, a cell, or nothing |
+| `p` | cycle [`HighlightPlacement`] |
+| `s` | cycle [`HighlightSpacing`] |
+| `q` | quit |
+
+The selection starts on the second column: `SelectedColumn` and `FirstColumn` are the same layout
+whenever the first column is the selected one.
+
+[`HighlightPlacement`]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.HighlightPlacement.html
+[`HighlightSpacing`]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.HighlightSpacing.html

--- a/examples/apps/selection/src/main.rs
+++ b/examples/apps/selection/src/main.rs
@@ -1,0 +1,191 @@
+//! Row, column, and cell selection.
+//!
+//! ```shell
+//! cargo run -p selection
+//! ```
+//!
+//! The arrow keys move the selection on both axes. The axis keys pick which of the three
+//! [`TableSelection`] variants is active, and the placement key decides which columns make room
+//! for the highlight symbol.
+
+use std::io::Result;
+
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::Line;
+use ratatui::widgets::Block;
+use ratatui::{DefaultTerminal, Frame};
+use ratatui_table::{HighlightPlacement, HighlightSpacing, Row, Table, TableSelection, TableState};
+
+const HEADER: [&str; 4] = ["Name", "Role", "City", "Joined"];
+
+const ITEMS: [[&str; 4]; 8] = [
+    ["Alice", "Engineer", "Berlin", "2019"],
+    ["Bob", "Designer", "Lisbon", "2020"],
+    ["Carol", "Engineer", "Toronto", "2020"],
+    ["Dan", "Support", "Nairobi", "2021"],
+    ["Erin", "Engineer", "Osaka", "2021"],
+    ["Frank", "Product", "Bogota", "2022"],
+    ["Grace", "Engineer", "Helsinki", "2023"],
+    ["Heidi", "Research", "Dunedin", "2024"],
+];
+
+const HELP: &str =
+    " ↑/↓ row  ←/→ column │ r row  c column  x cell  n none │ p placement  s spacing │ q quit ";
+
+fn main() -> Result<()> {
+    ratatui::run(|terminal| App::new().run(terminal))
+}
+
+struct App {
+    items: Vec<Vec<&'static str>>,
+    state: TableState,
+    placement: HighlightPlacement,
+    spacing: HighlightSpacing,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            items: ITEMS.iter().map(|item| item.to_vec()).collect(),
+            state: TableState::new().with_selected_cell(Some((0, 1))),
+            placement: HighlightPlacement::FirstColumn,
+            spacing: HighlightSpacing::Always,
+        }
+    }
+
+    fn run(mut self, terminal: &mut DefaultTerminal) -> Result<()> {
+        loop {
+            terminal.draw(|frame| self.draw(frame))?;
+            if let Event::Key(key) = event::read()?
+                && key.kind == KeyEventKind::Press
+            {
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Down | KeyCode::Char('j') => self.state.select_next_row(),
+                    KeyCode::Up | KeyCode::Char('k') => self.state.select_previous_row(),
+                    KeyCode::Right | KeyCode::Char('l') => self.state.select_next_column(),
+                    KeyCode::Left | KeyCode::Char('h') => self.state.select_previous_column(),
+                    KeyCode::Char('r') => self.state.set_selection(TableSelection::Row(self.row())),
+                    KeyCode::Char('c') => {
+                        self.state
+                            .set_selection(TableSelection::Column(self.column()));
+                    }
+                    KeyCode::Char('x') => self.state.set_selection(TableSelection::Cell {
+                        row: self.row(),
+                        column: self.column(),
+                    }),
+                    KeyCode::Char('n') => self.state.set_selection(None),
+                    KeyCode::Char('p') => self.placement = next_placement(&self.placement),
+                    KeyCode::Char('s') => self.spacing = next_spacing(&self.spacing),
+                    _ => {}
+                }
+                self.clamp_selection();
+            }
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame) {
+        let [config_area, table_area, help_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .areas(frame.area());
+
+        // The configuration is rendered around the table rather than inside it, so the table shows
+        // nothing but the effect of the current settings.
+        frame.render_widget(self.config_line(), config_area);
+        let table = self.table();
+        frame.render_stateful_widget(table, table_area, &mut self.state);
+        frame.render_widget(Line::from(HELP).dim(), help_area);
+    }
+
+    fn table(&self) -> Table<'static> {
+        let rows = self.items.iter().map(|item| Row::new(item.iter().copied()));
+        let widths = [
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Length(6),
+        ];
+        Table::new(rows, widths)
+            .header(Row::new(HEADER).style(Style::new().bold()))
+            .block(Block::bordered().title(" ratatui-table "))
+            .row_highlight_style(Style::new().bg(Color::Indexed(17)))
+            .column_highlight_style(Style::new().bg(Color::Indexed(22)))
+            .cell_highlight_style(Style::new().bg(Color::Indexed(130)))
+            .highlight_symbol(">>")
+            .highlight_spacing(self.spacing.clone())
+            .highlight_placement(self.placement.clone())
+    }
+
+    fn config_line(&self) -> Line<'static> {
+        Line::from(format!(
+            " selection: {}   placement: {}   spacing: {} ",
+            selection_label(self.state.selection()),
+            placement_label(&self.placement),
+            self.spacing,
+        ))
+        .bold()
+    }
+
+    /// The row the axis keys switch to, which is the selected one when there is one.
+    fn row(&self) -> usize {
+        self.state.selected_row().unwrap_or(0)
+    }
+
+    /// The column the axis keys switch to, which is the selected one when there is one.
+    fn column(&self) -> usize {
+        self.state.selected_column().unwrap_or(0)
+    }
+
+    /// Keeps the selection inside the table.
+    ///
+    /// The navigation methods deliberately do not know the table's size — an out of range index is
+    /// clamped on render — so a demo that displays the indexes has to clamp them itself.
+    fn clamp_selection(&mut self) {
+        let last_row = self.items.len().saturating_sub(1);
+        let last_column = HEADER.len().saturating_sub(1);
+        if let Some(row) = self.state.selected_row() {
+            self.state.select_row(Some(row.min(last_row)));
+        }
+        if let Some(column) = self.state.selected_column() {
+            self.state.select_column(Some(column.min(last_column)));
+        }
+    }
+}
+
+fn next_placement(placement: &HighlightPlacement) -> HighlightPlacement {
+    match placement {
+        HighlightPlacement::FirstColumn => HighlightPlacement::SelectedColumn,
+        HighlightPlacement::SelectedColumn => HighlightPlacement::Columns(vec![0, 2]),
+        HighlightPlacement::Columns(_) => HighlightPlacement::AllColumns,
+        HighlightPlacement::AllColumns => HighlightPlacement::FirstColumn,
+    }
+}
+
+const fn next_spacing(spacing: &HighlightSpacing) -> HighlightSpacing {
+    match spacing {
+        HighlightSpacing::Always => HighlightSpacing::WhenSelected,
+        HighlightSpacing::WhenSelected => HighlightSpacing::Never,
+        HighlightSpacing::Never => HighlightSpacing::Always,
+    }
+}
+
+fn placement_label(placement: &HighlightPlacement) -> String {
+    match placement {
+        HighlightPlacement::Columns(columns) => format!("Columns({columns:?})"),
+        other => other.to_string(),
+    }
+}
+
+fn selection_label(selection: Option<TableSelection>) -> String {
+    match selection {
+        Some(TableSelection::Row(row)) => format!("Row({row})"),
+        Some(TableSelection::Column(column)) => format!("Column({column})"),
+        Some(TableSelection::Cell { row, column }) => format!("Cell({row}, {column})"),
+        None => "None".to_string(),
+    }
+}

--- a/examples/vhs/selection.tape
+++ b/examples/vhs/selection.tape
@@ -1,0 +1,42 @@
+# Records examples/apps/selection into target/selection.gif. Install
+# https://github.com/charmbracelet/vhs, then run this from the repository root:
+#
+#   just record selection
+
+Output target/selection.gif
+
+Set Shell bash
+Set FontSize 18
+Set Width 900
+Set Height 460
+Set Padding 12
+
+Hide
+Type "cargo run --quiet -p selection" Enter
+Sleep 3s
+Show
+
+Sleep 1s
+Down@400ms 3
+Right@400ms 2
+Sleep 1s
+
+# Row, then column, then cell, so each highlight style shows on its own.
+Type "r" Sleep 1500ms
+Type "c" Sleep 1500ms
+Type "x" Sleep 1500ms
+
+# The symbol column follows the selection, then lands on every column.
+Type "p" Sleep 1500ms
+Left@500ms 2
+Sleep 1s
+Type "p" Sleep 1500ms
+Type "p" Sleep 1500ms
+Type "p" Sleep 1500ms
+
+# Without a selection, WhenSelected drops the symbol column entirely.
+Type "s" Sleep 1s
+Type "n" Sleep 2s
+
+Type "q"
+Sleep 1s

--- a/justfile
+++ b/justfile
@@ -23,6 +23,13 @@ test:
     cargo test --no-default-features
     cargo test --no-default-features --features serde
 
+examples:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Record an example with https://github.com/charmbracelet/vhs, into target/<example>.gif
+record example="":
+    cargo build -p "{{example}}"
+    vhs examples/vhs/"{{example}}.tape"
 docs:
     RUSTC="$(rustup which --toolchain nightly rustc)" \
       RUSTDOC="$(rustup which --toolchain nightly rustdoc)" \
@@ -47,4 +54,4 @@ semver-checks:
 package:
     cargo package --locked --allow-dirty
 
-check-all: fmt-check clippy-all test docs rdme-check deny minimal-versions semver-checks package
+check-all: fmt-check clippy-all test examples docs rdme-check deny minimal-versions semver-checks package

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! other changes independently.
 //!
 //! [`3d8639c`]: https://github.com/ratatui/ratatui/commit/3d8639cbb2f910200f30e680a8923ccaf99ba1bf
+//! [`Table`]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.Table.html
 //!
 //! This crate is an opt-in development path for the built-in widget, not a competing Table design.
 //! If the experiment succeeds, Ratatui should be able to offer an easy upgrade or re-export path.
@@ -46,16 +47,25 @@
 //!
 //! # Ratatui compatibility
 //!
-//! [`Table::block`] accepts [`ratatui_widgets::block::Block`] to preserve the built-in API. This
-//! means the initial crate depends on `ratatui-widgets` with default features disabled. A future
-//! Ratatui facade can re-export this crate without requiring this crate to become part of
-//! `ratatui-widgets` itself.
+//! [`Table::block`][block] accepts a ratatui-widgets [`Block`][block-widget] to preserve the
+//! built-in API. This means the initial crate depends on `ratatui-widgets` with default features
+//! disabled. A future Ratatui facade can re-export this crate without requiring this crate to
+//! become part of `ratatui-widgets` itself.
+//!
+//! [block]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.Table.html#method.block
+//! [block-widget]: https://docs.rs/ratatui-widgets/latest/ratatui_widgets/block/struct.Block.html
 //!
 //! # Feature flags
 //!
 //! - `std` enables the standard-library features of the Ratatui dependencies. The Table itself
 //!   remains usable with `no_std` plus `alloc` by default.
-//! - `serde` adds serialization and deserialization for [`TableState`] and [`HighlightSpacing`].
+//! - `serde` adds serialization and deserialization for [`TableState`], [`TableSelection`],
+//!   [`HighlightSpacing`][hs], and [`HighlightPlacement`][hp].
+//!
+//! [`TableState`]: https://docs.rs/ratatui-table/latest/ratatui_table/struct.TableState.html
+//! [`TableSelection`]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.TableSelection.html
+//! [hs]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.HighlightSpacing.html
+//! [hp]: https://docs.rs/ratatui-table/latest/ratatui_table/enum.HighlightPlacement.html
 //!
 //! # Governance
 //!
@@ -68,4 +78,6 @@ extern crate alloc;
 mod table;
 
 #[doc(inline)]
-pub use table::{Cell, HighlightSpacing, Row, Table, TableState};
+pub use table::{
+    Cell, HighlightPlacement, HighlightSpacing, Row, Table, TableSelection, TableState,
+};

--- a/src/table.rs
+++ b/src/table.rs
@@ -13,11 +13,13 @@ use ratatui_core::widgets::{StatefulWidget, Widget};
 use ratatui_widgets::block::{Block, BlockExt};
 
 pub use self::cell::Cell;
+pub use self::highlight_placement::HighlightPlacement;
 pub use self::highlight_spacing::HighlightSpacing;
 pub use self::row::Row;
-pub use self::state::TableState;
+pub use self::state::{TableSelection, TableState};
 
 mod cell;
+mod highlight_placement;
 mod highlight_spacing;
 mod row;
 mod state;
@@ -43,6 +45,26 @@ mod state;
 ///
 /// Note: if the `widths` field is empty, the table will be rendered with equal widths.
 /// Note: Highlight styles are applied in the following order: Row, Column, Cell.
+///
+/// # Selection and highlighting
+///
+/// A [`TableState`] holds at most one [`TableSelection`] — a row, a column, or a single cell. The
+/// three axes are not independent flags: selecting a column while a row is selected produces a
+/// cell selection, and clearing the row again leaves the column selected. See [`TableSelection`]
+/// for the full transition rules.
+///
+/// What the selection draws is controlled by three independent settings:
+///
+/// - the highlight *styles* ([`Table::row_highlight_style`], [`Table::column_highlight_style`],
+///   [`Table::cell_highlight_style`]) paint the selected row, column, and their intersection. The
+///   column highlight covers the rows area only — never the header or the footer.
+/// - [`Table::highlight_symbol`] is the marker drawn in front of the selection, and
+///   [`Table::highlight_spacing`] decides *when* space is reserved for it. Because any selection
+///   reserves the space, a column-only selection widens the table the same way a row selection
+///   does.
+/// - [`Table::highlight_placement`] decides *which* columns that space is added to. The default
+///   indents the first column only, which is why a table that never selects a column lays out
+///   exactly as it did before column selection existed.
 ///
 /// See the table example and the recipe and traceroute tabs in the demo2 example in the [Examples]
 /// directory for a more in depth example of the various configuration options and for how to handle
@@ -71,6 +93,7 @@ mod state;
 /// - [`Table::cell_highlight_style`] sets the style of the selected cell.
 /// - [`Table::highlight_symbol`] sets the symbol to be displayed in front of the selected row.
 /// - [`Table::highlight_spacing`] sets when to show the highlight spacing.
+/// - [`Table::highlight_placement`] sets which columns the highlight spacing is added to.
 ///
 /// # Example
 ///
@@ -269,6 +292,9 @@ pub struct Table<'a> {
     /// Decides when to allocate spacing for the row selection
     highlight_spacing: HighlightSpacing,
 
+    /// Decides which columns get spacing for the highlight symbol
+    highlight_placement: HighlightPlacement,
+
     /// Controls how to distribute extra space among the columns
     flex: Flex,
 }
@@ -288,6 +314,7 @@ impl Default for Table<'_> {
             cell_highlight_style: Style::new(),
             highlight_symbol: Text::default(),
             highlight_spacing: HighlightSpacing::default(),
+            highlight_placement: HighlightPlacement::default(),
             flex: Flex::Start,
         }
     }
@@ -695,6 +722,33 @@ impl<'a> Table<'a> {
         self
     }
 
+    /// Set which columns get space for the highlight symbol.
+    ///
+    /// Reads as a pair with [`Table::highlight_spacing`]: that one decides *when* the symbol
+    /// column is allocated, this one decides *where*. Defaults to
+    /// [`HighlightPlacement::FirstColumn`], which reproduces the layout of a table without column
+    /// selection.
+    ///
+    /// See [`HighlightPlacement`] for how the columns shift as the selection moves.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui::layout::Constraint;
+    /// use ratatui_table::{HighlightPlacement, Row, Table};
+    ///
+    /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
+    /// let widths = [Constraint::Length(5), Constraint::Length(5)];
+    /// let table = Table::new(rows, widths).highlight_placement(HighlightPlacement::SelectedColumn);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn highlight_placement(mut self, value: HighlightPlacement) -> Self {
+        self.highlight_placement = value;
+        self
+    }
+
     /// Set how extra space is distributed amongst columns.
     ///
     /// This determines how the space is distributed when the constraints are satisfied. By default,
@@ -757,29 +811,31 @@ impl StatefulWidget for &Table<'_> {
             return;
         }
 
-        if state.selected.is_some_and(|s| s >= self.rows.len()) {
-            state.select(Some(self.rows.len().saturating_sub(1)));
-        }
-
-        if self.rows.is_empty() {
-            state.select(None);
-        }
-
         let column_count = self.column_count();
-        if state.selected_column.is_some_and(|s| s >= column_count) {
-            state.select_column(Some(column_count.saturating_sub(1)));
-        }
-        if column_count == 0 {
-            state.select_column(None);
-        }
+        state.clamp(self.rows.len(), column_count);
 
         let selection_width = self.selection_width(state);
-        let column_widths = self.get_column_widths(table_area.width, selection_width, column_count);
+        let symbol_columns = self
+            .highlight_placement
+            .column_mask(state.selected_column(), column_count);
+        let column_widths = self.get_column_widths(
+            table_area.width,
+            selection_width,
+            column_count,
+            &symbol_columns,
+        );
         let (header_area, rows_area, footer_area) = self.layout(table_area);
 
         self.render_header(header_area, buf, &column_widths);
 
-        self.render_rows(rows_area, buf, selection_width, state, &column_widths);
+        self.render_rows(
+            rows_area,
+            buf,
+            selection_width,
+            state,
+            &column_widths,
+            &symbol_columns,
+        );
 
         self.render_footer(footer_area, buf, &column_widths);
     }
@@ -850,6 +906,7 @@ impl Table<'_> {
         selection_width: u16,
         state: &mut TableState,
         columns_widths: &[Rect],
+        symbol_columns: &[bool],
     ) {
         if self.rows.is_empty() {
             return;
@@ -873,10 +930,18 @@ impl Table<'_> {
             let row_area = Rect { y, height, ..area };
             buf.set_style(row_area, row.style);
 
-            let is_selected = state.selected.is_some_and(|index| index == i);
-            if selection_width > 0 && is_selected {
-                self.set_selection_style(buf, selection_width, row_area, row);
-            }
+            let is_selected = state.selected_row() == Some(i);
+            self.render_highlight_symbol(
+                buf,
+                row_area,
+                row,
+                i,
+                start_index,
+                state,
+                columns_widths,
+                symbol_columns,
+                selection_width,
+            );
             self.render_row_cells(buf, columns_widths.iter().collect(), &row.cells, row_area);
             if is_selected {
                 selected_row_area = Some(row_area);
@@ -884,7 +949,7 @@ impl Table<'_> {
             y_offset += row.height_with_margin();
         }
 
-        let selected_column_area = state.selected_column.and_then(|s| {
+        let selected_column_area = state.selected_column().and_then(|s| {
             // The selection is clamped by the column count. Since a user can manually specify an
             // incorrect number of widths, we should use panic free methods.
             columns_widths.get(s).map(|cell_area| Rect {
@@ -937,20 +1002,53 @@ impl Table<'_> {
         }
     }
 
-    /// Set the row style and render the highlight symbol
-    fn set_selection_style(
+    /// Render the highlight symbol into every slot of the selected row.
+    ///
+    /// The two axes are anchored independently: [`HighlightPlacement`] alone decides which columns
+    /// have a slot, and the selection alone decides which row the symbols land on. Requiring the
+    /// slot to sit at the *selected* column instead would erase the symbol under the default
+    /// [`HighlightPlacement::FirstColumn`] whenever a column other than the first is selected.
+    ///
+    /// A column-only selection has no row to anchor to, so it uses the topmost visible row —
+    /// pinning it to row 0 would hide the symbol as soon as the table scrolls.
+    ///
+    /// Slots are per *column index*, not per [`Cell`]: [`Cell::column_span`] makes the two differ,
+    /// so folding this into `render_row_cells` would misplace the symbol on spanned rows.
+    #[expect(clippy::too_many_arguments)]
+    fn render_highlight_symbol(
         &self,
         buf: &mut Buffer,
-        selection_width: u16,
         row_area: Rect,
         row: &Row,
+        row_index: usize,
+        first_visible_row: usize,
+        state: &TableState,
+        columns_widths: &[Rect],
+        symbol_columns: &[bool],
+        selection_width: u16,
     ) {
-        let selection_area = Rect {
-            width: selection_width,
-            ..row_area
+        if selection_width == 0 {
+            return;
+        }
+        let Some(selection) = state.selection() else {
+            return;
         };
-        buf.set_style(selection_area, row.style);
-        (&self.highlight_symbol).render(selection_area, buf);
+        if row_index != selection.row().unwrap_or(first_visible_row) {
+            return;
+        }
+
+        for (column_index, cell_area) in columns_widths.iter().enumerate() {
+            if !symbol_columns.get(column_index).copied().unwrap_or(false) {
+                continue;
+            }
+            let symbol_area = Rect {
+                x: (row_area.x + cell_area.x).saturating_sub(selection_width),
+                width: selection_width,
+                ..row_area
+            };
+            buf.set_style(symbol_area, row.style);
+            (&self.highlight_symbol).render(symbol_area, buf);
+        }
     }
 
     /// Return the area that a [`Cell`] should occupy, taking into account its
@@ -1000,7 +1098,7 @@ impl Table<'_> {
         let last_row = self.rows.len().saturating_sub(1);
         let mut start = state.offset.min(last_row);
 
-        if let Some(selected) = state.selected {
+        if let Some(selected) = state.selected_row() {
             start = start.min(selected);
         }
 
@@ -1015,7 +1113,7 @@ impl Table<'_> {
             end += 1;
         }
 
-        if let Some(selected) = state.selected {
+        if let Some(selected) = state.selected_row() {
             let selected = selected.min(last_row);
 
             // scroll down until the selected row is visible
@@ -1046,6 +1144,7 @@ impl Table<'_> {
         max_width: u16,
         selection_width: u16,
         col_count: usize,
+        symbol_columns: &[bool],
     ) -> Vec<Rect> {
         let widths = if self.widths.is_empty() {
             // Divide the space between each column equally
@@ -1053,17 +1152,28 @@ impl Table<'_> {
         } else {
             self.widths.clone()
         };
-        // this will always allocate a selection area
-        let [_selection_area, columns_area] =
-            Layout::horizontal([Constraint::Length(selection_width), Constraint::Fill(0)])
-                .areas(Rect::new(0, 0, max_width, 1));
+
+        // Reserve one symbol slot per qualifying column up front, lay the columns out in what is
+        // left, then push each column right past the slots that precede it. Two passes rather
+        // than interleaving the slots into the constraints, so `flex` and `column_spacing` keep
+        // acting on the columns alone.
+        let slots = symbol_columns.iter().filter(|slot| **slot).count() as u16;
+        let content_width = max_width.saturating_sub(selection_width * slots);
         let rects = Layout::horizontal(widths)
             .flex(self.flex)
             .spacing(self.column_spacing)
-            .split(columns_area);
+            .split(Rect::new(0, 0, content_width, 1));
+
+        let mut shift = 0;
         rects
             .iter()
-            .map(|c| Rect::new(c.x, 0, c.width, 1))
+            .enumerate()
+            .map(|(index, rect)| {
+                if symbol_columns.get(index).copied().unwrap_or(false) {
+                    shift += selection_width;
+                }
+                Rect::new(rect.x + shift, 0, rect.width, 1)
+            })
             .collect()
     }
 
@@ -1077,10 +1187,13 @@ impl Table<'_> {
             .unwrap_or_default()
     }
 
-    /// Returns the width of the selection column if a row is selected, or the `highlight_spacing`
-    /// is set to show the column always, otherwise 0.
+    /// Returns the width of the selection column if anything is selected, or the
+    /// `highlight_spacing` is set to show the column always, otherwise 0.
+    ///
+    /// Any selection counts, not just a row: `HighlightPlacement::SelectedColumn` would have
+    /// nowhere to draw if a column-only selection reserved no space.
     fn selection_width(&self, state: &TableState) -> u16 {
-        let has_selection = state.selected.is_some();
+        let has_selection = state.selection().is_some();
         if self.highlight_spacing.should_add(has_selection) {
             self.highlight_symbol.width() as u16
         } else {
@@ -1341,10 +1454,10 @@ mod tests {
             let rows: Vec<Row> = Vec::new();
             let widths = vec![Constraint::Percentage(100)];
             let table = Table::new(rows, widths);
-            state.select_first();
+            state.select_first_row();
             StatefulWidget::render(table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected, None);
-            assert_eq!(state.selected_column, None);
+            assert_eq!(state.selected_row(), None);
+            assert_eq!(state.selected_column(), None);
         }
 
         #[rstest]
@@ -1355,47 +1468,47 @@ mod tests {
 
             let items = vec![Row::new(vec!["Item 1"])];
             let table = Table::new(items, widths);
-            state.select_first();
+            state.select_first_row();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected, Some(0));
-            assert_eq!(state.selected_column, None);
+            assert_eq!(state.selected_row(), Some(0));
+            assert_eq!(state.selected_column(), None);
 
-            state.select_last();
+            state.select_last_row();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected, Some(0));
-            assert_eq!(state.selected_column, None);
+            assert_eq!(state.selected_row(), Some(0));
+            assert_eq!(state.selected_column(), None);
 
-            state.select_previous();
+            state.select_previous_row();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected, Some(0));
-            assert_eq!(state.selected_column, None);
+            assert_eq!(state.selected_row(), Some(0));
+            assert_eq!(state.selected_column(), None);
 
-            state.select_next();
+            state.select_next_row();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected, Some(0));
-            assert_eq!(state.selected_column, None);
+            assert_eq!(state.selected_row(), Some(0));
+            assert_eq!(state.selected_column(), None);
 
             let mut state = TableState::default();
 
             state.select_first_column();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected_column, Some(0));
-            assert_eq!(state.selected, None);
+            assert_eq!(state.selected_column(), Some(0));
+            assert_eq!(state.selected_row(), None);
 
             state.select_last_column();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected_column, Some(0));
-            assert_eq!(state.selected, None);
+            assert_eq!(state.selected_column(), Some(0));
+            assert_eq!(state.selected_row(), None);
 
             state.select_previous_column();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected_column, Some(0));
-            assert_eq!(state.selected, None);
+            assert_eq!(state.selected_column(), Some(0));
+            assert_eq!(state.selected_row(), None);
 
             state.select_next_column();
             StatefulWidget::render(&table, table_buf.area, &mut table_buf, &mut state);
-            assert_eq!(state.selected_column, Some(0));
-            assert_eq!(state.selected, None);
+            assert_eq!(state.selected_column(), Some(0));
+            assert_eq!(state.selected_row(), None);
         }
     }
 
@@ -1712,7 +1825,7 @@ mod tests {
             let table = Table::new(rows, [Constraint::Length(5); 2])
                 .row_highlight_style(Style::new().red())
                 .highlight_symbol(">>");
-            let mut state = TableState::new().with_selected(Some(0));
+            let mut state = TableState::new().with_selected_row(Some(0));
             StatefulWidget::render(table, Rect::new(0, 0, 15, 3), &mut buf, &mut state);
             let expected = Buffer::with_lines([
                 ">>Cell1 Cell2  ".red(),
@@ -1736,18 +1849,18 @@ mod tests {
             StatefulWidget::render(table, Rect::new(0, 0, 15, 3), &mut buf, &mut state);
             let expected = Buffer::with_lines::<[Line; 3]>([
                 Line::from(vec![
-                    "Cell1".into(),
+                    ">>Cell1".into(),
                     " ".into(),
                     "Cell2".blue(),
-                    "    ".into(),
+                    "  ".into(),
                 ]),
                 Line::from(vec![
-                    "Cell3".into(),
+                    "  Cell3".into(),
                     " ".into(),
                     "Cell4".blue(),
-                    "    ".into(),
+                    "  ".into(),
                 ]),
-                Line::from(vec!["      ".into(), "     ".blue(), "    ".into()]),
+                Line::from(vec!["        ".into(), "     ".blue(), "  ".into()]),
             ]);
             assert_eq!(buf, expected);
         }
@@ -1786,7 +1899,9 @@ mod tests {
                 .highlight_symbol(">>")
                 .row_highlight_style(Style::new().red())
                 .column_highlight_style(Style::new().blue());
-            let mut state = TableState::new().with_selected(1).with_selected_column(2);
+            let mut state = TableState::new()
+                .with_selected_row(1)
+                .with_selected_column(2);
             StatefulWidget::render(table, Rect::new(0, 0, 20, 4), &mut buf, &mut state);
             let expected = Buffer::with_lines::<[Line; 4]>([
                 Line::from(vec!["  Cell1 ".into(), "Cell2 ".into(), "Cell3".blue()]),
@@ -1810,7 +1925,9 @@ mod tests {
                 .row_highlight_style(Style::new().red())
                 .column_highlight_style(Style::new().blue())
                 .cell_highlight_style(Style::new().green());
-            let mut state = TableState::new().with_selected(1).with_selected_column(2);
+            let mut state = TableState::new()
+                .with_selected_row(1)
+                .with_selected_column(2);
             StatefulWidget::render(table, Rect::new(0, 0, 20, 4), &mut buf, &mut state);
             let expected = Buffer::with_lines::<[Line; 4]>([
                 Line::from(vec!["  Cell1 ".into(), "Cell2 ".into(), "Cell3".blue()]),
@@ -1843,12 +1960,199 @@ mod tests {
             let mut buf = Buffer::empty(Rect::new(0, 0, 2, 5));
             let mut state = TableState::new()
                 .with_offset(50)
-                .with_selected(selected_row.into());
+                .with_selected_row(selected_row.into());
 
             StatefulWidget::render(table.clone(), Rect::new(0, 0, 5, 5), &mut buf, &mut state);
 
             assert_eq!(buf, Buffer::with_lines(expected_items));
             assert_eq!(state.offset, expected_offset);
+        }
+    }
+
+    mod highlight_placement {
+        use super::*;
+
+        /// Renders a 3x3 table of `A1`..`C3` in a 24x3 area and compares the lines.
+        #[track_caller]
+        fn assert_render(
+            placement: HighlightPlacement,
+            selection: TableSelection,
+            expected: [&str; 3],
+        ) {
+            let rows = [
+                Row::new(["A1", "A2", "A3"]),
+                Row::new(["B1", "B2", "B3"]),
+                Row::new(["C1", "C2", "C3"]),
+            ];
+            let table = Table::new(rows, [Constraint::Length(2); 3])
+                .highlight_symbol(">>")
+                .highlight_placement(placement);
+            let mut state = TableState::new().with_selection(selection);
+            let area = Rect::new(0, 0, 24, 3);
+            let mut buf = Buffer::empty(area);
+            StatefulWidget::render(table, area, &mut buf, &mut state);
+            assert_eq!(buf, Buffer::with_lines(expected));
+        }
+
+        #[test]
+        fn first_column_with_row_selection() {
+            assert_render(
+                HighlightPlacement::FirstColumn,
+                TableSelection::Row(1),
+                [
+                    "  A1 A2 A3              ",
+                    ">>B1 B2 B3              ",
+                    "  C1 C2 C3              ",
+                ],
+            );
+        }
+
+        #[test]
+        fn first_column_keeps_symbol_when_a_later_column_is_selected() {
+            // The slot is at column 0, the selection is at column 2. The symbol still shows.
+            assert_render(
+                HighlightPlacement::FirstColumn,
+                TableSelection::Cell { row: 1, column: 2 },
+                [
+                    "  A1 A2 A3              ",
+                    ">>B1 B2 B3              ",
+                    "  C1 C2 C3              ",
+                ],
+            );
+        }
+
+        #[test]
+        fn selected_column_moves_the_slot() {
+            assert_render(
+                HighlightPlacement::SelectedColumn,
+                TableSelection::Cell { row: 1, column: 1 },
+                [
+                    "A1   A2 A3              ",
+                    "B1 >>B2 B3              ",
+                    "C1   C2 C3              ",
+                ],
+            );
+        }
+
+        #[test]
+        fn selected_column_without_a_column_falls_back_to_first() {
+            assert_render(
+                HighlightPlacement::SelectedColumn,
+                TableSelection::Row(0),
+                [
+                    ">>A1 A2 A3              ",
+                    "  B1 B2 B3              ",
+                    "  C1 C2 C3              ",
+                ],
+            );
+        }
+
+        #[test]
+        fn columns_indents_each_listed_column() {
+            assert_render(
+                HighlightPlacement::Columns(vec![1, 2]),
+                TableSelection::Row(0),
+                [
+                    "A1 >>A2 >>A3            ",
+                    "B1   B2   B3            ",
+                    "C1   C2   C3            ",
+                ],
+            );
+        }
+
+        #[test]
+        fn columns_ignores_out_of_range_indices() {
+            // Index 9 does not exist: no panic, and no slot allocated for it.
+            assert_render(
+                HighlightPlacement::Columns(vec![1, 9]),
+                TableSelection::Row(0),
+                [
+                    "A1 >>A2 A3              ",
+                    "B1   B2 B3              ",
+                    "C1   C2 C3              ",
+                ],
+            );
+        }
+
+        #[test]
+        fn all_columns() {
+            assert_render(
+                HighlightPlacement::AllColumns,
+                TableSelection::Row(2),
+                [
+                    "  A1   A2   A3          ",
+                    "  B1   B2   B3          ",
+                    ">>C1 >>C2 >>C3          ",
+                ],
+            );
+        }
+
+        #[test]
+        fn column_only_selection_anchors_to_the_first_visible_row() {
+            // Scrolled past row 0: the symbol must follow the viewport, not stay on row 0 where
+            // nobody can see it.
+            let rows = ["A", "B", "C", "D"].map(|label| Row::new([label, label]));
+            let table = Table::new(rows, [Constraint::Length(1); 2])
+                .highlight_symbol(">>")
+                .highlight_placement(HighlightPlacement::SelectedColumn);
+            let mut state = TableState::new().with_offset(2).with_selected_column(1);
+            let area = Rect::new(0, 0, 8, 2);
+            let mut buf = Buffer::empty(area);
+            StatefulWidget::render(table, area, &mut buf, &mut state);
+            assert_eq!(buf, Buffer::with_lines(["C >>C   ", "D   D   "]));
+        }
+
+        #[test]
+        fn never_spacing_allocates_no_slot() {
+            let rows = [Row::new(["A1", "A2"]), Row::new(["B1", "B2"])];
+            let table = Table::new(rows, [Constraint::Length(2); 2])
+                .highlight_symbol(">>")
+                .highlight_spacing(HighlightSpacing::Never)
+                .highlight_placement(HighlightPlacement::AllColumns);
+            let mut state = TableState::new().with_selected_row(0);
+            let area = Rect::new(0, 0, 12, 2);
+            let mut buf = Buffer::empty(area);
+            StatefulWidget::render(table, area, &mut buf, &mut state);
+            assert_eq!(buf, Buffer::with_lines(["A1 A2       ", "B1 B2       "]));
+        }
+
+        #[test]
+        fn symbol_follows_columns_not_spanned_cells() {
+            // The first cell spans two columns, so cell index 1 is column index 2. With a slot on
+            // every column the symbols must still land on column boundaries.
+            let rows = [Row::new([
+                Cell::from("A1").column_span(2),
+                Cell::from("A3"),
+            ])];
+            let table = Table::new(rows, [Constraint::Length(2); 3])
+                .header(Row::new(["H1", "H2", "H3"]))
+                .highlight_symbol(">>")
+                .highlight_placement(HighlightPlacement::AllColumns);
+            let mut state = TableState::new().with_selected_row(0);
+            let area = Rect::new(0, 0, 20, 2);
+            let mut buf = Buffer::empty(area);
+            StatefulWidget::render(table, area, &mut buf, &mut state);
+            assert_eq!(
+                buf,
+                Buffer::with_lines(["  H1   H2   H3      ", ">>A1 >>   >>A3      "])
+            );
+        }
+
+        #[test]
+        fn column_highlight_does_not_reach_header_or_footer() {
+            let rows = [Row::new(["A1", "A2"])];
+            let table = Table::new(rows, [Constraint::Length(2); 2])
+                .header(Row::new(["H1", "H2"]))
+                .footer(Row::new(["F1", "F2"]))
+                .column_highlight_style(Style::new().blue());
+            let mut state = TableState::new().with_selected_column(1);
+            let area = Rect::new(0, 0, 6, 3);
+            let mut buf = Buffer::empty(area);
+            StatefulWidget::render(table, area, &mut buf, &mut state);
+
+            let mut expected = Buffer::with_lines(["H1 H2 ", "A1 A2 ", "F1 F2 "]);
+            expected.set_style(Rect::new(3, 1, 2, 1), Style::new().blue());
+            assert_eq!(buf, expected);
         }
     }
 
@@ -1861,21 +2165,21 @@ mod tests {
             // without selection, more than needed width
             let table = Table::default().widths([Length(4), Length(4)]);
             assert_eq!(
-                table.get_column_widths(20, 0, 0),
+                table.get_column_widths(20, 0, 0, &[]),
                 [Rect::new(0, 0, 4, 1), Rect::new(5, 0, 4, 1),]
             );
 
             // with selection, more than needed width
             let table = Table::default().widths([Length(4), Length(4)]);
             assert_eq!(
-                table.get_column_widths(20, 3, 0),
+                table.get_column_widths(20, 3, 0, &[true]),
                 [Rect::new(3, 0, 4, 1), Rect::new(8, 0, 4, 1)]
             );
 
             // without selection, less than needed width
             let table = Table::default().widths([Length(4), Length(4)]);
             assert_eq!(
-                table.get_column_widths(7, 0, 0),
+                table.get_column_widths(7, 0, 0, &[]),
                 [Rect::new(0, 0, 3, 1), Rect::new(4, 0, 3, 1)]
             );
 
@@ -1887,7 +2191,7 @@ mod tests {
             // column spacing (i.e. `x`) is always prioritized
             let table = Table::default().widths([Length(4), Length(4)]);
             assert_eq!(
-                table.get_column_widths(7, 3, 0),
+                table.get_column_widths(7, 3, 0, &[true]),
                 [Rect::new(3, 0, 2, 1), Rect::new(6, 0, 1, 1)]
             );
         }
@@ -1897,28 +2201,28 @@ mod tests {
             // without selection, more than needed width
             let table = Table::default().widths([Max(4), Max(4)]);
             assert_eq!(
-                table.get_column_widths(20, 0, 0),
+                table.get_column_widths(20, 0, 0, &[]),
                 [Rect::new(0, 0, 4, 1), Rect::new(5, 0, 4, 1)]
             );
 
             // with selection, more than needed width
             let table = Table::default().widths([Max(4), Max(4)]);
             assert_eq!(
-                table.get_column_widths(20, 3, 0),
+                table.get_column_widths(20, 3, 0, &[true]),
                 [Rect::new(3, 0, 4, 1), Rect::new(8, 0, 4, 1)]
             );
 
             // without selection, less than needed width
             let table = Table::default().widths([Max(4), Max(4)]);
             assert_eq!(
-                table.get_column_widths(7, 0, 0),
+                table.get_column_widths(7, 0, 0, &[]),
                 [Rect::new(0, 0, 3, 1), Rect::new(4, 0, 3, 1)]
             );
 
             // with selection, less than needed width
             let table = Table::default().widths([Max(4), Max(4)]);
             assert_eq!(
-                table.get_column_widths(7, 3, 0),
+                table.get_column_widths(7, 3, 0, &[true]),
                 [Rect::new(3, 0, 2, 1), Rect::new(6, 0, 1, 1)]
             );
         }
@@ -1932,14 +2236,14 @@ mod tests {
             // without selection, more than needed width
             let table = Table::default().widths([Min(4), Min(4)]);
             assert_eq!(
-                table.get_column_widths(20, 0, 0),
+                table.get_column_widths(20, 0, 0, &[]),
                 [Rect::new(0, 0, 10, 1), Rect::new(11, 0, 9, 1)]
             );
 
             // with selection, more than needed width
             let table = Table::default().widths([Min(4), Min(4)]);
             assert_eq!(
-                table.get_column_widths(20, 3, 0),
+                table.get_column_widths(20, 3, 0, &[true]),
                 [Rect::new(3, 0, 8, 1), Rect::new(12, 0, 8, 1)]
             );
 
@@ -1947,7 +2251,7 @@ mod tests {
             // allocates spacer
             let table = Table::default().widths([Min(4), Min(4)]);
             assert_eq!(
-                table.get_column_widths(7, 0, 0),
+                table.get_column_widths(7, 0, 0, &[]),
                 [Rect::new(0, 0, 3, 1), Rect::new(4, 0, 3, 1)]
             );
 
@@ -1955,7 +2259,7 @@ mod tests {
             // always allocates selection and spacer
             let table = Table::default().widths([Min(4), Min(4)]);
             assert_eq!(
-                table.get_column_widths(7, 3, 0),
+                table.get_column_widths(7, 3, 0, &[true]),
                 [Rect::new(3, 0, 2, 1), Rect::new(6, 0, 1, 1)]
             );
         }
@@ -1965,14 +2269,14 @@ mod tests {
             // without selection, more than needed width
             let table = Table::default().widths([Percentage(30), Percentage(30)]);
             assert_eq!(
-                table.get_column_widths(20, 0, 0),
+                table.get_column_widths(20, 0, 0, &[]),
                 [Rect::new(0, 0, 6, 1), Rect::new(7, 0, 6, 1)]
             );
 
             // with selection, more than needed width
             let table = Table::default().widths([Percentage(30), Percentage(30)]);
             assert_eq!(
-                table.get_column_widths(20, 3, 0),
+                table.get_column_widths(20, 3, 0, &[true]),
                 [Rect::new(3, 0, 5, 1), Rect::new(9, 0, 5, 1)]
             );
 
@@ -1980,7 +2284,7 @@ mod tests {
             // rounds from positions: [0.0, 0.0, 2.1, 3.1, 5.2, 7.0]
             let table = Table::default().widths([Percentage(30), Percentage(30)]);
             assert_eq!(
-                table.get_column_widths(7, 0, 0),
+                table.get_column_widths(7, 0, 0, &[]),
                 [Rect::new(0, 0, 2, 1), Rect::new(3, 0, 2, 1)]
             );
 
@@ -1988,7 +2292,7 @@ mod tests {
             // rounds from positions: [0.0, 3.0, 5.1, 6.1, 7.0, 7.0]
             let table = Table::default().widths([Percentage(30), Percentage(30)]);
             assert_eq!(
-                table.get_column_widths(7, 3, 0),
+                table.get_column_widths(7, 3, 0, &[true]),
                 [Rect::new(3, 0, 1, 1), Rect::new(5, 0, 1, 1)]
             );
         }
@@ -1999,7 +2303,7 @@ mod tests {
             // rounds from positions: [0.00, 0.00, 6.67, 7.67, 14.33]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
             assert_eq!(
-                table.get_column_widths(20, 0, 0),
+                table.get_column_widths(20, 0, 0, &[]),
                 [Rect::new(0, 0, 7, 1), Rect::new(8, 0, 6, 1)]
             );
 
@@ -2007,7 +2311,7 @@ mod tests {
             // rounds from positions: [0.00, 3.00, 10.67, 17.33, 20.00]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
             assert_eq!(
-                table.get_column_widths(20, 3, 0),
+                table.get_column_widths(20, 3, 0, &[true]),
                 [Rect::new(3, 0, 6, 1), Rect::new(10, 0, 5, 1)]
             );
 
@@ -2015,7 +2319,7 @@ mod tests {
             // rounds from positions: [0.00, 2.33, 3.33, 5.66, 7.00]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
             assert_eq!(
-                table.get_column_widths(7, 0, 0),
+                table.get_column_widths(7, 0, 0, &[]),
                 [Rect::new(0, 0, 2, 1), Rect::new(3, 0, 3, 1)]
             );
 
@@ -2023,7 +2327,7 @@ mod tests {
             // rounds from positions: [0.00, 3.00, 5.33, 6.33, 7.00, 7.00]
             let table = Table::default().widths([Ratio(1, 3), Ratio(1, 3)]);
             assert_eq!(
-                table.get_column_widths(7, 3, 0),
+                table.get_column_widths(7, 3, 0, &[true]),
                 [Rect::new(3, 0, 1, 1), Rect::new(5, 0, 2, 1)]
             );
         }
@@ -2033,7 +2337,7 @@ mod tests {
         fn underconstrained_flex() {
             let table = Table::default().widths([Min(10), Min(10), Min(1)]);
             assert_eq!(
-                table.get_column_widths(62, 0, 0),
+                table.get_column_widths(62, 0, 0, &[]),
                 &[
                     Rect::new(0, 0, 20, 1),
                     Rect::new(21, 0, 20, 1),
@@ -2045,7 +2349,7 @@ mod tests {
                 .widths([Min(10), Min(10), Min(1)])
                 .flex(Flex::Legacy);
             assert_eq!(
-                table.get_column_widths(62, 0, 0),
+                table.get_column_widths(62, 0, 0, &[]),
                 &[
                     Rect::new(0, 0, 10, 1),
                     Rect::new(11, 0, 10, 1),
@@ -2057,7 +2361,7 @@ mod tests {
                 .widths([Min(10), Min(10), Min(1)])
                 .flex(Flex::SpaceBetween);
             assert_eq!(
-                table.get_column_widths(62, 0, 0),
+                table.get_column_widths(62, 0, 0, &[]),
                 &[
                     Rect::new(0, 0, 20, 1),
                     Rect::new(21, 0, 20, 1),
@@ -2070,7 +2374,7 @@ mod tests {
         fn underconstrained_segment_size() {
             let table = Table::default().widths([Min(10), Min(10), Min(1)]);
             assert_eq!(
-                table.get_column_widths(62, 0, 0),
+                table.get_column_widths(62, 0, 0, &[]),
                 &[
                     Rect::new(0, 0, 20, 1),
                     Rect::new(21, 0, 20, 1),
@@ -2082,7 +2386,7 @@ mod tests {
                 .widths([Min(10), Min(10), Min(1)])
                 .flex(Flex::Legacy);
             assert_eq!(
-                table.get_column_widths(62, 0, 0),
+                table.get_column_widths(62, 0, 0, &[]),
                 &[
                     Rect::new(0, 0, 10, 1),
                     Rect::new(11, 0, 10, 1),
@@ -2103,7 +2407,7 @@ mod tests {
                 .footer(Row::new(vec!["h", "i"]))
                 .column_spacing(0);
             assert_eq!(
-                table.get_column_widths(30, 0, 3),
+                table.get_column_widths(30, 0, 3, &[]),
                 &[
                     Rect::new(0, 0, 10, 1),
                     Rect::new(10, 0, 10, 1),
@@ -2119,7 +2423,7 @@ mod tests {
                 .header(Row::new(vec!["f", "g"]))
                 .column_spacing(0);
             assert_eq!(
-                table.get_column_widths(10, 0, 2),
+                table.get_column_widths(10, 0, 2, &[]),
                 [Rect::new(0, 0, 5, 1), Rect::new(5, 0, 5, 1)]
             );
         }
@@ -2131,7 +2435,7 @@ mod tests {
                 .footer(Row::new(vec!["h", "i"]))
                 .column_spacing(0);
             assert_eq!(
-                table.get_column_widths(10, 0, 2),
+                table.get_column_widths(10, 0, 2, &[]),
                 [Rect::new(0, 0, 5, 1), Rect::new(5, 0, 5, 1)]
             );
         }
@@ -2154,7 +2458,7 @@ mod tests {
                 .column_spacing(spacing);
             let area = Rect::new(0, 0, columns, 3);
             let mut buf = Buffer::empty(area);
-            let mut state = TableState::default().with_selected(selection);
+            let mut state = TableState::default().with_selected_row(selection);
             StatefulWidget::render(table, area, &mut buf, &mut state);
             assert_eq!(buf, Buffer::with_lines(expected));
         }
@@ -2713,7 +3017,7 @@ mod tests {
             .column_spacing(spacing);
         let area = Rect::new(0, 0, columns, 3);
         let mut buf = Buffer::empty(area);
-        let mut state = TableState::default().with_selected(selection);
+        let mut state = TableState::default().with_selected_row(selection);
         StatefulWidget::render(table, area, &mut buf, &mut state);
         assert_eq!(buf, Buffer::with_lines(expected));
     }

--- a/src/table/highlight_placement.rs
+++ b/src/table/highlight_placement.rs
@@ -1,0 +1,187 @@
+use alloc::vec::Vec;
+
+use strum::{Display, EnumString};
+
+/// Where the highlight symbol gets space, i.e. *which* columns are indented to make room for it.
+///
+/// [`HighlightSpacing`] decides *when* the symbol column is allocated; this decides *where*.
+///
+/// [`HighlightSpacing`]: super::HighlightSpacing
+///
+/// # How the layout moves
+///
+/// Every column that gets a slot is pushed right by the symbol width, and the remaining width is
+/// split between the columns. With a 2-cell symbol `>>` and three columns:
+///
+/// ```text
+/// FirstColumn      >>Alice   Engineer  Berlin
+/// SelectedColumn     Alice >>Engineer  Berlin      (column 1 selected)
+/// SelectedColumn     Alice   Engineer>>Berlin      (column 2 selected)
+/// AllColumns       >>Alice >>Engineer>>Berlin
+/// ```
+///
+/// Note the consequence of [`SelectedColumn`]: moving the selection from one column to the next
+/// moves the slot with it, so text to the left of the new slot shifts left and text to its right
+/// shifts right. Use [`FirstColumn`] (the default) or [`AllColumns`] if you need the columns to
+/// stay put as the selection moves.
+///
+/// [`SelectedColumn`]: HighlightPlacement::SelectedColumn
+/// [`FirstColumn`]: HighlightPlacement::FirstColumn
+/// [`AllColumns`]: HighlightPlacement::AllColumns
+#[derive(Debug, Display, EnumString, PartialEq, Eq, Clone, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum HighlightPlacement {
+    /// Only the first column gets a slot.
+    ///
+    /// This is the default, and reproduces the behavior of a table without column selection: the
+    /// symbol sits at the left edge of the row and the layout never moves.
+    #[default]
+    FirstColumn,
+
+    /// Only the selected column gets a slot.
+    ///
+    /// The slot follows the selection, so the columns shift as the selected column changes. With
+    /// no column selected, falls back to the first column.
+    SelectedColumn,
+
+    /// Each listed column gets a slot.
+    ///
+    /// Indices at or beyond the column count are ignored. Parsing this variant from a string
+    /// yields an empty list, i.e. no slots.
+    Columns(Vec<usize>),
+
+    /// Every column gets a slot.
+    AllColumns,
+}
+
+impl HighlightPlacement {
+    /// Returns a `column_count`-long mask: `mask[i]` is true when column `i` gets a symbol slot.
+    ///
+    /// A mask rather than a list of indices because the render path asks "does column `i` have a
+    /// slot" once per column; a `contains()` lookup inside that loop would be quadratic.
+    pub(crate) fn column_mask(
+        &self,
+        selected_column: Option<usize>,
+        column_count: usize,
+    ) -> Vec<bool> {
+        let mut mask = alloc::vec![false; column_count];
+        match self {
+            Self::AllColumns => mask.fill(true),
+            Self::FirstColumn => {
+                if let Some(first) = mask.first_mut() {
+                    *first = true;
+                }
+            }
+            Self::SelectedColumn => {
+                // No column selected: behave like `FirstColumn` rather than showing no symbol.
+                if let Some(slot) = mask.get_mut(selected_column.unwrap_or(0)) {
+                    *slot = true;
+                }
+            }
+            Self::Columns(indices) => {
+                for &index in indices {
+                    if let Some(slot) = mask.get_mut(index) {
+                        *slot = true;
+                    }
+                }
+            }
+        }
+        mask
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn to_string() {
+        assert_eq!(
+            HighlightPlacement::FirstColumn.to_string(),
+            "FirstColumn".to_string()
+        );
+        assert_eq!(
+            HighlightPlacement::SelectedColumn.to_string(),
+            "SelectedColumn".to_string()
+        );
+        assert_eq!(
+            HighlightPlacement::Columns(vec![1]).to_string(),
+            "Columns".to_string()
+        );
+        assert_eq!(
+            HighlightPlacement::AllColumns.to_string(),
+            "AllColumns".to_string()
+        );
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(
+            "FirstColumn".parse::<HighlightPlacement>(),
+            Ok(HighlightPlacement::FirstColumn)
+        );
+        assert_eq!(
+            "SelectedColumn".parse::<HighlightPlacement>(),
+            Ok(HighlightPlacement::SelectedColumn)
+        );
+        assert_eq!(
+            "Columns".parse::<HighlightPlacement>(),
+            Ok(HighlightPlacement::Columns(Vec::new()))
+        );
+        assert_eq!(
+            "AllColumns".parse::<HighlightPlacement>(),
+            Ok(HighlightPlacement::AllColumns)
+        );
+        assert_eq!(
+            "".parse::<HighlightPlacement>(),
+            Err(strum::ParseError::VariantNotFound)
+        );
+    }
+
+    #[test]
+    fn mask_first_column() {
+        let mask = HighlightPlacement::FirstColumn.column_mask(Some(2), 3);
+        assert_eq!(mask, vec![true, false, false]);
+    }
+
+    #[test]
+    fn mask_selected_column() {
+        let mask = HighlightPlacement::SelectedColumn.column_mask(Some(2), 3);
+        assert_eq!(mask, vec![false, false, true]);
+    }
+
+    #[test]
+    fn mask_selected_column_without_selection() {
+        let mask = HighlightPlacement::SelectedColumn.column_mask(None, 3);
+        assert_eq!(mask, vec![true, false, false]);
+    }
+
+    #[test]
+    fn mask_columns_ignores_out_of_range() {
+        let mask = HighlightPlacement::Columns(vec![1, 9]).column_mask(None, 3);
+        assert_eq!(mask, vec![false, true, false]);
+    }
+
+    #[test]
+    fn mask_all_columns() {
+        let mask = HighlightPlacement::AllColumns.column_mask(None, 3);
+        assert_eq!(mask, vec![true, true, true]);
+    }
+
+    #[test]
+    fn mask_zero_columns() {
+        assert!(
+            HighlightPlacement::AllColumns
+                .column_mask(Some(0), 0)
+                .is_empty()
+        );
+        assert!(
+            HighlightPlacement::FirstColumn
+                .column_mask(None, 0)
+                .is_empty()
+        );
+    }
+}

--- a/src/table/highlight_placement.rs
+++ b/src/table/highlight_placement.rs
@@ -173,15 +173,13 @@ mod tests {
 
     #[test]
     fn mask_zero_columns() {
-        assert!(
-            HighlightPlacement::AllColumns
-                .column_mask(Some(0), 0)
-                .is_empty()
+        assert_eq!(
+            HighlightPlacement::AllColumns.column_mask(Some(0), 0),
+            Vec::<bool>::new()
         );
-        assert!(
-            HighlightPlacement::FirstColumn
-                .column_mask(None, 0)
-                .is_empty()
+        assert_eq!(
+            HighlightPlacement::FirstColumn.column_mask(None, 0),
+            Vec::<bool>::new()
         );
     }
 }

--- a/src/table/state.rs
+++ b/src/table/state.rs
@@ -7,12 +7,16 @@
 ///
 /// The state consists of two fields:
 /// - [`offset`]: the index of the first row to be displayed
-/// - [`selected`]: the index of the selected row, which can be `None` if no row is selected
-/// - [`selected_column`]: the index of the selected column, which can be `None` if no column is
-///   selected
+/// - [`selection`]: what is selected — a row, a column, or a cell — or `None`
 ///
 /// [`offset`]: TableState::offset()
-/// [`selected`]: TableState::selected()
+/// [`selection`]: TableState::selection()
+///
+/// Every accessor names the axis it acts on. [`selected_row`] and [`selected_column`] read one
+/// component out of the selection; [`selection`] returns the whole [`TableSelection`]. The
+/// unqualified `selected`/`select` names are deprecated aliases for the row-axis methods.
+///
+/// [`selected_row`]: TableState::selected_row()
 /// [`selected_column`]: TableState::selected_column()
 ///
 /// See the `table` example and the `recipe` and `traceroute` tabs in the demo2 example in the
@@ -38,7 +42,7 @@
 /// // method) so that the selected row is preserved across renders
 /// let mut table_state = TableState::default();
 /// *table_state.offset_mut() = 1; // display the second row and onwards
-/// table_state.select(Some(3)); // select the forth row (0-indexed)
+/// table_state.select_row(Some(3)); // select the forth row (0-indexed)
 /// table_state.select_column(Some(2)); // select the third column (0-indexed)
 ///
 /// frame.render_stateful_widget(table, area, &mut table_state);
@@ -54,12 +58,121 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableState {
     pub(crate) offset: usize,
-    pub(crate) selected: Option<usize>,
-    pub(crate) selected_column: Option<usize>,
+    pub(crate) selection: Option<TableSelection>,
+}
+
+/// What is currently selected in a [`Table`].
+///
+/// - [`Row`] — a full row is highlighted; no column is active.
+/// - [`Column`] — a full column is highlighted; no row is active.
+/// - [`Cell`] — a specific (row, column) intersection is highlighted.
+///
+/// Held by [`TableState`]. Use the component setters on that type ([`select_row`],
+/// [`select_column`]) to change one axis at a time, or [`set_selection`] to replace the whole
+/// value.
+///
+/// [`Table`]: super::Table
+/// [`Row`]: TableSelection::Row
+/// [`Column`]: TableSelection::Column
+/// [`Cell`]: TableSelection::Cell
+/// [`select_row`]: TableState::select_row
+/// [`select_column`]: TableState::select_column
+/// [`set_selection`]: TableState::set_selection
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TableSelection {
+    /// The row at this index is selected. No column is active.
+    Row(usize),
+    /// The column at this index is selected. No row is active.
+    Column(usize),
+    /// The intersection of a row and a column is selected.
+    Cell {
+        /// Index of the selected row.
+        row: usize,
+        /// Index of the selected column.
+        column: usize,
+    },
+}
+
+impl From<usize> for TableSelection {
+    /// Converts a bare index to [`TableSelection::Row`].
+    fn from(value: usize) -> Self {
+        Self::Row(value)
+    }
+}
+
+impl TableSelection {
+    /// Returns the row index if this selection includes one.
+    pub const fn row(&self) -> Option<usize> {
+        match *self {
+            Self::Row(row) | Self::Cell { row, .. } => Some(row),
+            Self::Column(_) => None,
+        }
+    }
+
+    /// Returns the column index if this selection includes one.
+    pub const fn column(&self) -> Option<usize> {
+        match *self {
+            Self::Column(column) | Self::Cell { column, .. } => Some(column),
+            Self::Row(_) => None,
+        }
+    }
+
+    /// Returns a new selection with the row component set to `row`.
+    ///
+    /// The single place all row-component transition logic lives. Private: the transition table
+    /// is documented on the public methods that use it ([`TableState::select_row`]).
+    ///
+    /// | current      | `row = Some(r)` | `row = None`  |
+    /// |--------------|-----------------|---------------|
+    /// | `None`       | `Row(r)`        | `None`        |
+    /// | `Row(_)`     | `Row(r)`        | `None`        |
+    /// | `Column(c)`  | `Cell{r, c}`    | `Column(c)`   |
+    /// | `Cell{_, c}` | `Cell{r, c}`    | `Column(c)`   |
+    pub(crate) const fn with_row(selection: Option<Self>, row: Option<usize>) -> Option<Self> {
+        match row {
+            Some(r) => Some(match selection {
+                Some(Self::Column(c) | Self::Cell { column: c, .. }) => {
+                    Self::Cell { row: r, column: c }
+                }
+                _ => Self::Row(r),
+            }),
+            None => match selection {
+                Some(Self::Column(c) | Self::Cell { column: c, .. }) => Some(Self::Column(c)),
+                _ => None,
+            },
+        }
+    }
+
+    /// Returns a new selection with the column component set to `column`.
+    ///
+    /// Mirror image of [`Self::with_row`].
+    ///
+    /// | current      | `column = Some(c)` | `column = None` |
+    /// |--------------|--------------------|-----------------|
+    /// | `None`       | `Column(c)`        | `None`          |
+    /// | `Row(r)`     | `Cell{r, c}`       | `Row(r)` (kept) |
+    /// | `Column(_)`  | `Column(c)`        | `None`          |
+    /// | `Cell{r, _}` | `Cell{r, c}`       | `Row(r)`        |
+    pub(crate) const fn with_column(
+        selection: Option<Self>,
+        column: Option<usize>,
+    ) -> Option<Self> {
+        match column {
+            Some(c) => Some(match selection {
+                Some(Self::Row(r) | Self::Cell { row: r, .. }) => Self::Cell { row: r, column: c },
+                _ => Self::Column(c),
+            }),
+            None => match selection {
+                Some(Self::Row(r) | Self::Cell { row: r, .. }) => Some(Self::Row(r)),
+                _ => None,
+            },
+        }
+    }
 }
 
 impl TableState {
-    /// Creates a new [`TableState`]
+    /// Creates a new [`TableState`] with no selection and offset 0.
     ///
     /// # Examples
     ///
@@ -71,8 +184,7 @@ impl TableState {
     pub const fn new() -> Self {
         Self {
             offset: 0,
-            selected: None,
-            selected_column: None,
+            selection: None,
         }
     }
 
@@ -93,68 +205,87 @@ impl TableState {
         self
     }
 
-    /// Sets the index of the selected row
+    /// Sets the selected row, preserving any existing column selection (fluent).
     ///
-    /// This is a fluent setter method which must be chained or used as it consumes self
+    /// Assigns the selection directly — does **not** reset `offset` even when passed `None`. Use
+    /// [`select_row`] if you need the offset reset on deselection.
     ///
-    /// # Examples
+    /// [`select_row`]: TableState::select_row
     ///
     /// ```rust
-    /// use ratatui_table::TableState;
+    /// use ratatui_table::{TableSelection, TableState};
     ///
-    /// let state = TableState::new().with_selected(Some(1));
+    /// let state = TableState::new().with_selected_row(3);
+    /// assert_eq!(state.selection(), Some(TableSelection::Row(3)));
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn with_selected<T>(mut self, selected: T) -> Self
+    pub fn with_selected_row<T>(mut self, selected: T) -> Self
     where
         T: Into<Option<usize>>,
     {
-        self.selected = selected.into();
+        self.selection = TableSelection::with_row(self.selection, selected.into());
         self
     }
 
-    /// Sets the index of the selected column
+    /// Sets the selected column, preserving any existing row selection (fluent).
     ///
-    /// This is a fluent setter method which must be chained or used as it consumes self
-    ///
-    /// # Examples
+    /// Assigns the selection directly — never resets `offset`.
     ///
     /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let state = TableState::new().with_selected_column(Some(1));
+    /// use ratatui_table::{TableSelection, TableState};
+    ///
+    /// let state = TableState::new().with_selected_column(2);
+    /// assert_eq!(state.selection(), Some(TableSelection::Column(2)));
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub fn with_selected_column<T>(mut self, selected: T) -> Self
     where
         T: Into<Option<usize>>,
     {
-        self.selected_column = selected.into();
+        self.selection = TableSelection::with_column(self.selection, selected.into());
         self
     }
 
-    /// Sets the indexes of the selected cell
+    /// Sets the selected cell by (row, column) pair (fluent).
     ///
-    /// This is a fluent setter method which must be chained or used as it consumes self
+    /// Passing `None` clears both axes. Does **not** reset `offset` — use [`select_cell`] if you
+    /// need that.
     ///
-    /// # Examples
+    /// [`select_cell`]: TableState::select_cell
     ///
     /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let state = TableState::new().with_selected_cell(Some((1, 5)));
+    /// use ratatui_table::TableState;
+    ///
+    /// let state = TableState::new().with_selected_cell((1, 5));
+    /// assert_eq!(state.selected_cell(), Some((1, 5)));
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
     pub fn with_selected_cell<T>(mut self, selected: T) -> Self
     where
         T: Into<Option<(usize, usize)>>,
     {
-        if let Some((r, c)) = selected.into() {
-            self.selected = Some(r);
-            self.selected_column = Some(c);
-        } else {
-            self.selected = None;
-            self.selected_column = None;
-        }
+        self.selection = selected
+            .into()
+            .map(|(row, column)| TableSelection::Cell { row, column });
+        self
+    }
 
+    /// Replaces the whole selection (fluent).
+    ///
+    /// Does **not** preserve either axis. Does **not** reset `offset`.
+    ///
+    /// ```rust
+    /// use ratatui_table::{TableSelection, TableState};
+    ///
+    /// let state = TableState::new().with_selection(TableSelection::Cell { row: 1, column: 2 });
+    /// assert_eq!(state.selected_cell(), Some((1, 2)));
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn with_selection<T>(mut self, selection: T) -> Self
+    where
+        T: Into<Option<TableSelection>>,
+    {
+        self.selection = selection.into();
         self
     }
 
@@ -186,350 +317,393 @@ impl TableState {
         &mut self.offset
     }
 
-    /// Index of the selected row
+    /// The full selection, or `None` if nothing is selected.
     ///
-    /// Returns `None` if no row is selected
+    /// ```rust
+    /// use ratatui_table::{TableSelection, TableState};
     ///
-    /// # Examples
+    /// let state = TableState::new().with_selected_column(Some(1));
+    /// assert_eq!(state.selection(), Some(TableSelection::Column(1)));
+    /// ```
+    pub const fn selection(&self) -> Option<TableSelection> {
+        self.selection
+    }
+
+    /// Mutable reference to the full selection.
+    ///
+    /// Prefer the component setters for single-axis changes; reach for this only when replacing
+    /// the entire value in one assignment.
+    ///
+    /// ```rust
+    /// use ratatui_table::{TableSelection, TableState};
+    ///
+    /// let mut state = TableState::new();
+    /// *state.selection_mut() = Some(TableSelection::Row(2));
+    /// assert_eq!(state.selected_row(), Some(2));
+    /// ```
+    pub const fn selection_mut(&mut self) -> &mut Option<TableSelection> {
+        &mut self.selection
+    }
+
+    /// Selected row index, or `None` if no row is part of the current selection.
+    ///
+    /// Returns `None` for a column-only selection.
     ///
     /// ```rust
     /// use ratatui_table::TableState;
     ///
-    /// let state = TableState::new();
-    /// assert_eq!(state.selected(), None);
+    /// assert_eq!(TableState::new().selected_row(), None);
     /// ```
-    pub const fn selected(&self) -> Option<usize> {
-        self.selected
+    pub const fn selected_row(&self) -> Option<usize> {
+        match self.selection {
+            Some(selection) => selection.row(),
+            None => None,
+        }
     }
 
-    /// Index of the selected column
+    /// Selected column index, or `None` if no column is part of the current selection.
     ///
-    /// Returns `None` if no column is selected
-    ///
-    /// # Examples
+    /// Returns `None` for a row-only selection.
     ///
     /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let state = TableState::new();
-    /// assert_eq!(state.selected_column(), None);
+    /// use ratatui_table::TableState;
+    ///
+    /// assert_eq!(TableState::new().selected_column(), None);
     /// ```
     pub const fn selected_column(&self) -> Option<usize> {
-        self.selected_column
+        match self.selection {
+            Some(selection) => selection.column(),
+            None => None,
+        }
     }
 
-    /// Indexes of the selected cell
+    /// Selected (row, column) pair, or `None` if the selection is not a [`Cell`].
     ///
-    /// Returns `None` if no cell is selected
+    /// Returns `None` for row-only and column-only selections.
     ///
-    /// # Examples
+    /// [`Cell`]: TableSelection::Cell
     ///
     /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let state = TableState::new();
-    /// assert_eq!(state.selected_cell(), None);
+    /// use ratatui_table::TableState;
+    ///
+    /// assert_eq!(TableState::new().selected_cell(), None);
     /// ```
     pub const fn selected_cell(&self) -> Option<(usize, usize)> {
-        if let (Some(r), Some(c)) = (self.selected, self.selected_column) {
-            return Some((r, c));
+        match self.selection {
+            Some(TableSelection::Cell { row, column }) => Some((row, column)),
+            _ => None,
         }
-        None
     }
 
-    /// Mutable reference to the index of the selected row
+    /// Replaces the whole selection.
     ///
-    /// Returns `None` if no row is selected
-    ///
-    /// # Examples
+    /// Does **not** preserve either axis and does **not** reset `offset`.
     ///
     /// ```rust
-    /// use ratatui_table::TableState;
+    /// use ratatui_table::{TableSelection, TableState};
     ///
-    /// let mut state = TableState::default();
-    /// *state.selected_mut() = Some(1);
+    /// let mut state = TableState::new();
+    ///
+    /// state.set_selection(Some(TableSelection::Cell { row: 0, column: 1 }));
+    /// assert_eq!(state.selected_cell(), Some((0, 1)));
     /// ```
-    pub const fn selected_mut(&mut self) -> &mut Option<usize> {
-        &mut self.selected
+    pub fn set_selection<T>(&mut self, selection: T)
+    where
+        T: Into<Option<TableSelection>>,
+    {
+        self.selection = selection.into();
     }
 
-    /// Mutable reference to the index of the selected column
+    /// Sets the selected row, preserving any existing column selection.
     ///
-    /// Returns `None` if no column is selected
+    /// This is a *component* setter: it changes the row axis and leaves the column axis alone, so
+    /// it can never produce a [`Column`] out of `Some`. Passing `None` clears the row axis, which
+    /// demotes a cell selection to column-only, and resets `offset` to 0. Use [`set_selection`] to
+    /// replace the whole selection instead.
     ///
-    /// # Examples
+    /// | current      | `row = Some(r)` | `row = None` |
+    /// |--------------|-----------------|--------------|
+    /// | `None`       | `Row(r)`        | `None`       |
+    /// | `Row(_)`     | `Row(r)`        | `None`       |
+    /// | `Column(c)`  | `Cell{r, c}`    | `Column(c)`  |
+    /// | `Cell{_, c}` | `Cell{r, c}`    | `Column(c)`  |
     ///
-    /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// *state.selected_column_mut() = Some(1);
-    /// ```
-    pub const fn selected_column_mut(&mut self) -> &mut Option<usize> {
-        &mut self.selected_column
-    }
-
-    /// Sets the index of the selected row
-    ///
-    /// Set to `None` if no row is selected. This will also reset the offset to `0`.
-    ///
-    /// # Examples
+    /// [`Column`]: TableSelection::Column
+    /// [`set_selection`]: TableState::set_selection
     ///
     /// ```rust
-    /// use ratatui_table::TableState;
+    /// use ratatui_table::{TableSelection, TableState};
     ///
-    /// let mut state = TableState::default();
-    /// state.select(Some(1));
+    /// let mut state = TableState::new().with_selected_column(Some(3));
+    ///
+    /// state.select_row(Some(1));
+    /// assert_eq!(
+    ///     state.selection(),
+    ///     Some(TableSelection::Cell { row: 1, column: 3 })
+    /// );
     /// ```
-    pub const fn select(&mut self, index: Option<usize>) {
-        self.selected = index;
-        if index.is_none() {
+    pub const fn select_row(&mut self, row: Option<usize>) {
+        if row.is_none() {
             self.offset = 0;
         }
+        self.selection = TableSelection::with_row(self.selection, row);
     }
 
-    /// Sets the index of the selected column
+    /// Sets the selected column, preserving any existing row selection.
     ///
-    /// # Examples
+    /// The mirror image of [`select_row`], except that it does **not** reset `offset` — the
+    /// column axis does not affect vertical scrolling.
+    ///
+    /// | current      | `column = Some(c)` | `column = None` |
+    /// |--------------|--------------------|-----------------|
+    /// | `None`       | `Column(c)`        | `None`          |
+    /// | `Row(r)`     | `Cell{r, c}`       | `Row(r)`        |
+    /// | `Column(_)`  | `Column(c)`        | `None`          |
+    /// | `Cell{r, _}` | `Cell{r, c}`       | `Row(r)`        |
+    ///
+    /// [`select_row`]: TableState::select_row
     ///
     /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// state.select_column(Some(1));
+    /// use ratatui_table::{TableSelection, TableState};
+    ///
+    /// let mut state = TableState::new().with_selected_row(Some(5));
+    ///
+    /// state.select_column(Some(2));
+    /// assert_eq!(
+    ///     state.selection(),
+    ///     Some(TableSelection::Cell { row: 5, column: 2 })
+    /// );
     /// ```
-    pub const fn select_column(&mut self, index: Option<usize>) {
-        self.selected_column = index;
+    pub const fn select_column(&mut self, column: Option<usize>) {
+        self.selection = TableSelection::with_column(self.selection, column);
     }
 
-    /// Sets the indexes of the selected cell
+    /// Sets the selected cell by (row, column) pair.
     ///
-    /// Set to `None` if no cell is selected. This will also reset the row offset to `0`.
-    ///
-    /// # Examples
+    /// Passing `None` clears both axes and resets `offset` to 0.
     ///
     /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
+    /// use ratatui_table::TableState;
+    ///
+    /// let mut state = TableState::new();
+    ///
     /// state.select_cell(Some((1, 5)));
+    /// assert_eq!(state.selected_cell(), Some((1, 5)));
     /// ```
     pub const fn select_cell(&mut self, indexes: Option<(usize, usize)>) {
-        if let Some((r, c)) = indexes {
-            self.selected = Some(r);
-            self.selected_column = Some(c);
+        if let Some((row, column)) = indexes {
+            self.selection = Some(TableSelection::Cell { row, column });
         } else {
             self.offset = 0;
-            self.selected = None;
-            self.selected_column = None;
+            self.selection = None;
         }
     }
 
-    /// Selects the next row or the first one if no row is selected
+    /// Selects the next row, or row 0 if no row is currently selected.
     ///
-    /// Note: until the table is rendered, the number of rows is not known, so the index is set to
-    /// `0` and will be corrected when the table is rendered
-    ///
-    /// # Examples
+    /// The index may exceed the actual row count; it is clamped on the next render.
     ///
     /// ```rust
     /// use ratatui_table::TableState;
-    ///
-    /// let mut state = TableState::default();
-    /// state.select_next();
+    /// let mut state = TableState::new();
+    /// state.select_next_row();
+    /// assert_eq!(state.selected_row(), Some(0));
     /// ```
-    pub fn select_next(&mut self) {
-        let next = self.selected.map_or(0, |i| i.saturating_add(1));
-        self.select(Some(next));
+    pub fn select_next_row(&mut self) {
+        let next = self.selected_row().map_or(0, |i| i.saturating_add(1));
+        self.select_row(Some(next));
     }
 
-    /// Selects the next column or the first one if no column is selected
-    ///
-    /// Note: until the table is rendered, the number of columns is not known, so the index is set
-    /// to `0` and will be corrected when the table is rendered
-    ///
-    /// # Examples
+    /// Selects the previous row, or `usize::MAX` (clamped on render) if no row is selected.
     ///
     /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// state.select_next_column();
+    /// use ratatui_table::TableState;
+    /// let mut state = TableState::new();
+    /// state.select_previous_row();
+    /// assert_eq!(state.selected_row(), Some(usize::MAX));
     /// ```
+    pub fn select_previous_row(&mut self) {
+        let prev = self
+            .selected_row()
+            .map_or(usize::MAX, |i| i.saturating_sub(1));
+        self.select_row(Some(prev));
+    }
+
+    /// Selects the next column, or column 0 if no column is currently selected.
+    ///
+    /// The index may exceed the actual column count; it is clamped on the next render.
     pub fn select_next_column(&mut self) {
-        let next = self.selected_column.map_or(0, |i| i.saturating_add(1));
+        let next = self.selected_column().map_or(0, |i| i.saturating_add(1));
         self.select_column(Some(next));
     }
 
-    /// Selects the previous row or the last one if no item is selected
-    ///
-    /// Note: until the table is rendered, the number of rows is not known, so the index is set to
-    /// `usize::MAX` and will be corrected when the table is rendered
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use ratatui_table::TableState;
-    ///
-    /// let mut state = TableState::default();
-    /// state.select_previous();
-    /// ```
-    pub fn select_previous(&mut self) {
-        let previous = self.selected.map_or(usize::MAX, |i| i.saturating_sub(1));
-        self.select(Some(previous));
-    }
-
-    /// Selects the previous column or the last one if no column is selected
-    ///
-    /// Note: until the table is rendered, the number of columns is not known, so the index is set
-    /// to `usize::MAX` and will be corrected when the table is rendered
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// state.select_previous_column();
-    /// ```
+    /// Selects the previous column, or `usize::MAX` (clamped on render) if no column is selected.
     pub fn select_previous_column(&mut self) {
-        let previous = self
-            .selected_column
+        let prev = self
+            .selected_column()
             .map_or(usize::MAX, |i| i.saturating_sub(1));
-        self.select_column(Some(previous));
+        self.select_column(Some(prev));
     }
 
-    /// Selects the first row
-    ///
-    /// Note: until the table is rendered, the number of rows is not known, so the index is set to
-    /// `0` and will be corrected when the table is rendered
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use ratatui_table::TableState;
-    ///
-    /// let mut state = TableState::default();
-    /// state.select_first();
-    /// ```
-    pub const fn select_first(&mut self) {
-        self.select(Some(0));
+    /// Selects the first row (index 0), preserving any existing column selection.
+    pub const fn select_first_row(&mut self) {
+        self.selection = TableSelection::with_row(self.selection, Some(0));
     }
 
-    /// Selects the first column
-    ///
-    /// Note: until the table is rendered, the number of columns is not known, so the index is set
-    /// to `0` and will be corrected when the table is rendered
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// state.select_first_column();
-    /// ```
+    /// Selects the last row (`usize::MAX`, clamped on render), preserving any column selection.
+    pub const fn select_last_row(&mut self) {
+        self.selection = TableSelection::with_row(self.selection, Some(usize::MAX));
+    }
+
+    /// Selects the first column (index 0), preserving any existing row selection.
     pub const fn select_first_column(&mut self) {
-        self.select_column(Some(0));
+        self.selection = TableSelection::with_column(self.selection, Some(0));
     }
 
-    /// Selects the last row
-    ///
-    /// Note: until the table is rendered, the number of rows is not known, so the index is set to
-    /// `usize::MAX` and will be corrected when the table is rendered
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use ratatui_table::TableState;
-    ///
-    /// let mut state = TableState::default();
-    /// state.select_last();
-    /// ```
-    pub const fn select_last(&mut self) {
-        self.select(Some(usize::MAX));
-    }
-
-    /// Selects the last column
-    ///
-    /// Note: until the table is rendered, the number of columns is not known, so the index is set
-    /// to `usize::MAX` and will be corrected when the table is rendered
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// state.select_last();
-    /// ```
+    /// Selects the last column (`usize::MAX`, clamped on render), preserving any row selection.
     pub const fn select_last_column(&mut self) {
-        self.select_column(Some(usize::MAX));
+        self.selection = TableSelection::with_column(self.selection, Some(usize::MAX));
     }
 
-    /// Scrolls down by a specified `amount` in the table.
-    ///
-    /// This method updates the selected index by moving it down by the given `amount`.
-    /// If the `amount` causes the index to go out of bounds (i.e., if the index is greater than
-    /// the number of rows in the table), the last row in the table will be selected.
-    ///
-    /// # Examples
+    /// Moves the row selection down by `amount`, saturating at `usize::MAX`.
     ///
     /// ```rust
     /// use ratatui_table::TableState;
-    ///
-    /// let mut state = TableState::default();
+    /// let mut state = TableState::new();
+    /// state.select_row(Some(2));
     /// state.scroll_down_by(4);
+    /// assert_eq!(state.selected_row(), Some(6));
     /// ```
     pub fn scroll_down_by(&mut self, amount: u16) {
-        let selected = self.selected.unwrap_or_default();
-        self.select(Some(selected.saturating_add(amount as usize)));
+        let next = self
+            .selected_row()
+            .unwrap_or(0)
+            .saturating_add(amount as usize);
+        self.select_row(Some(next));
     }
 
-    /// Scrolls up by a specified `amount` in the table.
-    ///
-    /// This method updates the selected index by moving it up by the given `amount`.
-    /// If the `amount` causes the index to go out of bounds (i.e., less than zero),
-    /// the first row in the table will be selected.
-    ///
-    /// # Examples
+    /// Moves the row selection up by `amount`, saturating at 0.
     ///
     /// ```rust
     /// use ratatui_table::TableState;
-    ///
-    /// let mut state = TableState::default();
+    /// let mut state = TableState::new();
+    /// state.select_row(Some(6));
     /// state.scroll_up_by(4);
+    /// assert_eq!(state.selected_row(), Some(2));
     /// ```
     pub fn scroll_up_by(&mut self, amount: u16) {
-        let selected = self.selected.unwrap_or_default();
-        self.select(Some(selected.saturating_sub(amount as usize)));
+        let prev = self
+            .selected_row()
+            .unwrap_or(0)
+            .saturating_sub(amount as usize);
+        self.select_row(Some(prev));
     }
 
-    /// Scrolls right by a specified `amount` in the table.
-    ///
-    /// This method updates the selected index by moving it right by the given `amount`.
-    /// If the `amount` causes the index to go out of bounds (i.e., if the index is greater than
-    /// the number of columns in the table), the last column in the table will be selected.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// state.scroll_right_by(4);
-    /// ```
+    /// Moves the column selection right by `amount`, saturating at `usize::MAX`.
     pub fn scroll_right_by(&mut self, amount: u16) {
-        let selected = self.selected_column.unwrap_or_default();
-        self.select_column(Some(selected.saturating_add(amount as usize)));
+        let next = self
+            .selected_column()
+            .unwrap_or(0)
+            .saturating_add(amount as usize);
+        self.select_column(Some(next));
     }
 
-    /// Scrolls left by a specified `amount` in the table.
-    ///
-    /// This method updates the selected index by moving it left by the given `amount`.
-    /// If the `amount` causes the index to go out of bounds (i.e., less than zero),
-    /// the first item in the table will be selected.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use ratatui_table::TableState;
-    /// let mut state = TableState::default();
-    /// state.scroll_left_by(4);
-    /// ```
+    /// Moves the column selection left by `amount`, saturating at 0.
     pub fn scroll_left_by(&mut self, amount: u16) {
-        let selected = self.selected_column.unwrap_or_default();
-        self.select_column(Some(selected.saturating_sub(amount as usize)));
+        let prev = self
+            .selected_column()
+            .unwrap_or(0)
+            .saturating_sub(amount as usize);
+        self.select_column(Some(prev));
+    }
+
+    /// Use [`selected_row`] instead.
+    ///
+    /// [`selected_row`]: TableState::selected_row
+    #[deprecated(since = "0.2.0", note = "renamed to `selected_row`")]
+    pub const fn selected(&self) -> Option<usize> {
+        self.selected_row()
+    }
+
+    /// Use [`select_row`] instead.
+    ///
+    /// [`select_row`]: TableState::select_row
+    #[deprecated(since = "0.2.0", note = "renamed to `select_row`")]
+    pub const fn select(&mut self, index: Option<usize>) {
+        self.select_row(index);
+    }
+
+    /// Use [`with_selected_row`] instead.
+    ///
+    /// [`with_selected_row`]: TableState::with_selected_row
+    #[deprecated(since = "0.2.0", note = "renamed to `with_selected_row`")]
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn with_selected<T>(self, selected: T) -> Self
+    where
+        T: Into<Option<usize>>,
+    {
+        self.with_selected_row(selected)
+    }
+
+    /// Use [`select_next_row`] instead.
+    ///
+    /// [`select_next_row`]: TableState::select_next_row
+    #[deprecated(since = "0.2.0", note = "renamed to `select_next_row`")]
+    pub fn select_next(&mut self) {
+        self.select_next_row();
+    }
+
+    /// Use [`select_previous_row`] instead.
+    ///
+    /// [`select_previous_row`]: TableState::select_previous_row
+    #[deprecated(since = "0.2.0", note = "renamed to `select_previous_row`")]
+    pub fn select_previous(&mut self) {
+        self.select_previous_row();
+    }
+
+    /// Use [`select_first_row`] instead.
+    ///
+    /// [`select_first_row`]: TableState::select_first_row
+    #[deprecated(since = "0.2.0", note = "renamed to `select_first_row`")]
+    pub const fn select_first(&mut self) {
+        self.select_first_row();
+    }
+
+    /// Use [`select_last_row`] instead.
+    ///
+    /// [`select_last_row`]: TableState::select_last_row
+    #[deprecated(since = "0.2.0", note = "renamed to `select_last_row`")]
+    pub const fn select_last(&mut self) {
+        self.select_last_row();
+    }
+
+    /// Clamps the selection to valid indices and adjusts the offset so the selected row is visible.
+    ///
+    /// Called by the renderer once it knows `row_count` and `column_count`. Sentinel values
+    /// (`usize::MAX` written by `select_last_row` / `select_last_column`) are rewritten to the
+    /// actual last index.
+    pub(crate) fn clamp(&mut self, row_count: usize, column_count: usize) {
+        // Zero rows/columns drop that axis entirely; a `Cell` demotes rather than vanishing.
+        // Matches the seed, which called `select(None)` / `select_column(None)` here.
+        if row_count == 0 {
+            self.select_row(None);
+        } else {
+            let last = row_count - 1;
+            self.selection = TableSelection::with_row(
+                self.selection,
+                self.selected_row().map(|row| row.min(last)),
+            );
+        }
+
+        if column_count == 0 {
+            self.select_column(None);
+        } else {
+            let last = column_count - 1;
+            self.selection = TableSelection::with_column(
+                self.selection,
+                self.selected_column().map(|column| column.min(last)),
+            );
+        }
     }
 }
 
@@ -541,205 +715,444 @@ mod tests {
     fn new() {
         let state = TableState::new();
         assert_eq!(state.offset, 0);
-        assert_eq!(state.selected, None);
-        assert_eq!(state.selected_column, None);
+        assert_eq!(state.selection, None);
     }
 
     #[test]
     fn with_offset() {
-        let state = TableState::new().with_offset(1);
-        assert_eq!(state.offset, 1);
+        assert_eq!(TableState::new().with_offset(1).offset, 1);
     }
 
     #[test]
-    fn with_selected() {
-        let state = TableState::new().with_selected(Some(1));
-        assert_eq!(state.selected, Some(1));
+    fn with_selected_row_some() {
+        let s = TableState::new().with_selected_row(Some(1));
+        assert_eq!(s.selection, Some(TableSelection::Row(1)));
     }
 
     #[test]
-    fn with_selected_column() {
-        let state = TableState::new().with_selected_column(Some(1));
-        assert_eq!(state.selected_column, Some(1));
+    fn with_selected_row_preserves_column() {
+        let s = TableState::new()
+            .with_selected_column(Some(2))
+            .with_selected_row(Some(1));
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell { row: 1, column: 2 })
+        );
+    }
+
+    #[test]
+    fn with_selected_row_none_does_not_reset_offset() {
+        // Builder must not route through select_row — offset must stay put.
+        let s = TableState::new().with_offset(5).with_selected_row(None);
+        assert_eq!(s.offset, 5);
+        assert_eq!(s.selection, None);
+    }
+
+    #[test]
+    fn with_selected_column_some() {
+        let s = TableState::new().with_selected_column(Some(1));
+        assert_eq!(s.selection, Some(TableSelection::Column(1)));
+    }
+
+    #[test]
+    fn with_selected_column_preserves_row() {
+        let s = TableState::new()
+            .with_selected_row(Some(3))
+            .with_selected_column(Some(1));
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell { row: 3, column: 1 })
+        );
+    }
+
+    #[test]
+    fn with_selected_cell_some() {
+        let s = TableState::new().with_selected_cell(Some((1, 5)));
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell { row: 1, column: 5 })
+        );
     }
 
     #[test]
     fn with_selected_cell_none() {
-        let state = TableState::new().with_selected_cell(None);
-        assert_eq!(state.selected, None);
-        assert_eq!(state.selected_column, None);
+        let s = TableState::new().with_offset(4).with_selected_cell(None);
+        assert_eq!(s.selection, None);
+        // with_selected_cell(None) clears selection but does NOT reset offset
+        assert_eq!(s.offset, 4);
     }
 
     #[test]
-    fn offset() {
-        let state = TableState::new();
-        assert_eq!(state.offset(), 0);
+    fn with_selection_replaces_whole() {
+        let sel = TableSelection::Cell { row: 2, column: 3 };
+        let s = TableState::new().with_selection(Some(sel));
+        assert_eq!(s.selection, Some(sel));
     }
 
     #[test]
-    fn offset_mut() {
-        let mut state = TableState::new();
-        *state.offset_mut() = 1;
-        assert_eq!(state.offset, 1);
+    fn offset_getter_and_mut() {
+        let mut s = TableState::new();
+        assert_eq!(s.offset(), 0);
+        *s.offset_mut() = 5;
+        assert_eq!(s.offset(), 5);
     }
 
     #[test]
-    fn selected() {
-        let state = TableState::new();
-        assert_eq!(state.selected(), None);
+    fn selection_getter_and_mut() {
+        let mut s = TableState::new();
+        assert_eq!(s.selection(), None);
+        *s.selection_mut() = Some(TableSelection::Row(7));
+        assert_eq!(s.selection(), Some(TableSelection::Row(7)));
     }
 
     #[test]
-    fn selected_column() {
-        let state = TableState::new();
-        assert_eq!(state.selected_column(), None);
+    fn selected_row_only() {
+        let s = TableState::new().with_selected_row(Some(3));
+        assert_eq!(s.selected_row(), Some(3));
+        assert_eq!(s.selected_column(), None);
+        assert_eq!(s.selected_cell(), None);
     }
 
     #[test]
-    fn selected_cell() {
-        let state = TableState::new();
-        assert_eq!(state.selected_cell(), None);
+    fn selected_column_only() {
+        let s = TableState::new().with_selected_column(Some(2));
+        assert_eq!(s.selected_row(), None);
+        assert_eq!(s.selected_column(), Some(2));
+        assert_eq!(s.selected_cell(), None);
     }
 
     #[test]
-    fn selected_mut() {
-        let mut state = TableState::new();
-        *state.selected_mut() = Some(1);
-        assert_eq!(state.selected, Some(1));
+    fn selected_cell_getters() {
+        let s = TableState::new().with_selected_cell(Some((4, 7)));
+        assert_eq!(s.selected_row(), Some(4));
+        assert_eq!(s.selected_column(), Some(7));
+        assert_eq!(s.selected_cell(), Some((4, 7)));
     }
 
     #[test]
-    fn selected_column_mut() {
-        let mut state = TableState::new();
-        *state.selected_column_mut() = Some(1);
-        assert_eq!(state.selected_column, Some(1));
+    fn select_row_from_none() {
+        let mut s = TableState::new();
+        s.select_row(Some(2));
+        assert_eq!(s.selection, Some(TableSelection::Row(2)));
     }
 
     #[test]
-    fn select() {
-        let mut state = TableState::new();
-        state.select(Some(1));
-        assert_eq!(state.selected, Some(1));
+    fn select_row_upgrades_to_cell() {
+        let mut s = TableState::new().with_selected_column(Some(3));
+        s.select_row(Some(1));
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell { row: 1, column: 3 })
+        );
     }
 
     #[test]
-    fn select_none() {
-        let mut state = TableState::new().with_selected(Some(1));
-        state.select(None);
-        assert_eq!(state.selected, None);
+    fn select_row_none_from_cell_keeps_column() {
+        let mut s = TableState::new().with_selected_cell(Some((2, 4)));
+        s.select_row(None);
+        assert_eq!(s.selection, Some(TableSelection::Column(4)));
+        assert_eq!(s.offset, 0);
     }
 
     #[test]
-    fn select_column() {
-        let mut state = TableState::new();
-        state.select_column(Some(1));
-        assert_eq!(state.selected_column, Some(1));
+    fn select_row_none_from_row_clears() {
+        let mut s = TableState::new().with_selected_row(Some(5)).with_offset(3);
+        s.select_row(None);
+        assert_eq!(s.selection, None);
+        assert_eq!(s.offset, 0);
     }
 
     #[test]
-    fn select_column_none() {
-        let mut state = TableState::new().with_selected_column(Some(1));
-        state.select_column(None);
-        assert_eq!(state.selected_column, None);
+    fn select_column_from_none() {
+        let mut s = TableState::new();
+        s.select_column(Some(2));
+        assert_eq!(s.selection, Some(TableSelection::Column(2)));
     }
 
     #[test]
-    fn select_cell() {
-        let mut state = TableState::new();
-        state.select_cell(Some((1, 5)));
-        assert_eq!(state.selected_cell(), Some((1, 5)));
+    fn select_column_upgrades_to_cell() {
+        let mut s = TableState::new().with_selected_row(Some(5));
+        s.select_column(Some(2));
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell { row: 5, column: 2 })
+        );
     }
 
     #[test]
-    fn select_cell_none() {
-        let mut state = TableState::new().with_selected_cell(Some((1, 5)));
-        state.select_cell(None);
-        assert_eq!(state.selected, None);
-        assert_eq!(state.selected_column, None);
-        assert_eq!(state.selected_cell(), None);
+    fn select_column_none_from_cell_keeps_row() {
+        let mut s = TableState::new().with_selected_cell(Some((3, 7)));
+        s.select_column(None);
+        assert_eq!(s.selection, Some(TableSelection::Row(3)));
     }
 
     #[test]
-    fn test_table_state_navigation() {
-        let mut state = TableState::default();
-        state.select_first();
-        assert_eq!(state.selected, Some(0));
+    fn select_column_none_does_not_reset_offset() {
+        let mut s = TableState::new()
+            .with_offset(5)
+            .with_selected_column(Some(2));
+        s.select_column(None);
+        assert_eq!(s.offset, 5);
+    }
 
-        state.select_previous(); // should not go below 0
-        assert_eq!(state.selected, Some(0));
+    #[test]
+    fn select_cell_and_clear() {
+        let mut s = TableState::new();
+        s.select_cell(Some((1, 5)));
+        assert_eq!(s.selected_cell(), Some((1, 5)));
+        s.select_cell(None);
+        assert_eq!(s.selection, None);
+        assert_eq!(s.offset, 0);
+    }
 
-        state.select_next();
-        assert_eq!(state.selected, Some(1));
+    #[test]
+    fn set_selection_replaces_whole() {
+        let mut s = TableState::new().with_selected_row(Some(10)).with_offset(3);
+        s.set_selection(Some(TableSelection::Column(3)));
+        assert_eq!(s.selection, Some(TableSelection::Column(3)));
+        assert_eq!(s.selected_row(), None);
+        // set_selection never touches offset
+        assert_eq!(s.offset, 3);
+    }
 
-        state.select_previous();
-        assert_eq!(state.selected, Some(0));
+    #[test]
+    fn navigation_rows() {
+        let mut s = TableState::new();
 
-        state.select_last();
-        assert_eq!(state.selected, Some(usize::MAX));
+        s.select_first_row();
+        assert_eq!(s.selected_row(), Some(0));
 
-        state.select_next(); // should not go above usize::MAX
-        assert_eq!(state.selected, Some(usize::MAX));
+        s.select_previous_row(); // saturates at 0
+        assert_eq!(s.selected_row(), Some(0));
 
-        state.select_previous();
-        assert_eq!(state.selected, Some(usize::MAX - 1));
+        s.select_next_row();
+        assert_eq!(s.selected_row(), Some(1));
 
-        state.select_next();
-        assert_eq!(state.selected, Some(usize::MAX));
+        s.select_last_row();
+        assert_eq!(s.selected_row(), Some(usize::MAX));
 
-        let mut state = TableState::default();
-        state.select_next();
-        assert_eq!(state.selected, Some(0));
+        s.select_next_row(); // saturates at usize::MAX
+        assert_eq!(s.selected_row(), Some(usize::MAX));
 
-        let mut state = TableState::default();
-        state.select_previous();
-        assert_eq!(state.selected, Some(usize::MAX));
+        s.select_previous_row();
+        assert_eq!(s.selected_row(), Some(usize::MAX - 1));
+    }
 
-        let mut state = TableState::default();
-        state.select(Some(2));
-        state.scroll_down_by(4);
-        assert_eq!(state.selected, Some(6));
+    #[test]
+    fn select_next_row_from_empty() {
+        let mut s = TableState::new();
+        s.select_next_row();
+        assert_eq!(s.selected_row(), Some(0));
+    }
 
-        let mut state = TableState::default();
-        state.scroll_up_by(3);
-        assert_eq!(state.selected, Some(0));
+    #[test]
+    fn select_previous_row_from_empty() {
+        let mut s = TableState::new();
+        s.select_previous_row();
+        assert_eq!(s.selected_row(), Some(usize::MAX));
+    }
 
-        state.select(Some(6));
-        state.scroll_up_by(4);
-        assert_eq!(state.selected, Some(2));
+    #[test]
+    fn first_last_row_preserve_column() {
+        let mut s = TableState::new().with_selected_column(Some(4));
+        s.select_first_row();
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell { row: 0, column: 4 })
+        );
+        s.select_last_row();
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell {
+                row: usize::MAX,
+                column: 4
+            })
+        );
+    }
 
-        state.scroll_up_by(4);
-        assert_eq!(state.selected, Some(0));
+    #[test]
+    fn navigation_columns() {
+        let mut s = TableState::new();
 
-        let mut state = TableState::default();
-        state.select_first_column();
-        assert_eq!(state.selected_column, Some(0));
+        s.select_first_column();
+        assert_eq!(s.selected_column(), Some(0));
 
-        state.select_previous_column();
-        assert_eq!(state.selected_column, Some(0));
+        s.select_previous_column(); // saturates at 0
+        assert_eq!(s.selected_column(), Some(0));
 
-        state.select_next_column();
-        assert_eq!(state.selected_column, Some(1));
+        s.select_next_column();
+        assert_eq!(s.selected_column(), Some(1));
 
-        state.select_previous_column();
-        assert_eq!(state.selected_column, Some(0));
+        s.select_last_column();
+        assert_eq!(s.selected_column(), Some(usize::MAX));
 
-        state.select_last_column();
-        assert_eq!(state.selected_column, Some(usize::MAX));
+        s.select_previous_column();
+        assert_eq!(s.selected_column(), Some(usize::MAX - 1));
+    }
 
-        state.select_previous_column();
-        assert_eq!(state.selected_column, Some(usize::MAX - 1));
+    #[test]
+    fn first_last_column_preserve_row() {
+        let mut s = TableState::new().with_selected_row(Some(2));
+        s.select_first_column();
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell { row: 2, column: 0 })
+        );
+        s.select_last_column();
+        assert_eq!(
+            s.selection,
+            Some(TableSelection::Cell {
+                row: 2,
+                column: usize::MAX
+            })
+        );
+    }
 
-        let mut state = TableState::default().with_selected_column(Some(12));
-        state.scroll_right_by(4);
-        assert_eq!(state.selected_column, Some(16));
+    #[test]
+    fn scroll_down_up() {
+        let mut s = TableState::new();
+        s.select_row(Some(2));
+        s.scroll_down_by(4);
+        assert_eq!(s.selected_row(), Some(6));
 
-        state.scroll_left_by(20);
-        assert_eq!(state.selected_column, Some(0));
+        s.scroll_up_by(4);
+        assert_eq!(s.selected_row(), Some(2));
 
-        state.scroll_right_by(100);
-        assert_eq!(state.selected_column, Some(100));
+        s.scroll_up_by(10); // saturates at 0
+        assert_eq!(s.selected_row(), Some(0));
+    }
 
-        state.scroll_left_by(20);
-        assert_eq!(state.selected_column, Some(80));
+    #[test]
+    fn scroll_right_left() {
+        let mut s = TableState::new().with_selected_column(Some(12));
+        s.scroll_right_by(4);
+        assert_eq!(s.selected_column(), Some(16));
+
+        s.scroll_left_by(20); // saturates at 0
+        assert_eq!(s.selected_column(), Some(0));
+
+        s.scroll_right_by(100);
+        assert_eq!(s.selected_column(), Some(100));
+
+        s.scroll_left_by(20);
+        assert_eq!(s.selected_column(), Some(80));
+    }
+
+    #[test]
+    fn clamp_row() {
+        let mut s = TableState::new().with_selected_row(Some(usize::MAX));
+        s.clamp(5, 3);
+        assert_eq!(s.selected_row(), Some(4));
+    }
+
+    #[test]
+    fn clamp_column() {
+        let mut s = TableState::new().with_selected_column(Some(usize::MAX));
+        s.clamp(5, 3);
+        assert_eq!(s.selected_column(), Some(2));
+    }
+
+    #[test]
+    fn clamp_cell() {
+        let mut s = TableState::new().with_selected_cell(Some((usize::MAX, usize::MAX)));
+        s.clamp(5, 3);
+        assert_eq!(s.selected_cell(), Some((4, 2)));
+    }
+
+    #[test]
+    fn clamp_zero_rows_drops_row_and_resets_offset() {
+        let mut s = TableState::new().with_offset(10).with_selected_row(Some(2));
+        s.clamp(0, 1);
+        assert_eq!(s.selection, None);
+        assert_eq!(s.offset, 0);
+    }
+
+    #[test]
+    fn clamp_zero_rows_demotes_cell_to_column() {
+        let mut s = TableState::new().with_selected_cell((2, 1));
+        s.clamp(0, 3);
+        assert_eq!(s.selection, Some(TableSelection::Column(1)));
+    }
+
+    #[test]
+    fn clamp_zero_columns_demotes_cell_to_row() {
+        let mut s = TableState::new().with_selected_cell((2, 1));
+        s.clamp(5, 0);
+        assert_eq!(s.selection, Some(TableSelection::Row(2)));
+    }
+
+    #[test]
+    fn clamp_leaves_offset_alone_when_in_range() {
+        let mut s = TableState::new().with_offset(10).with_selected_row(Some(2));
+        s.clamp(5, 1);
+        assert_eq!(s.offset, 10);
+    }
+
+    #[test]
+    fn usize_converts_to_row() {
+        assert_eq!(TableSelection::from(3), TableSelection::Row(3));
+        assert_eq!(Into::<TableSelection>::into(5usize), TableSelection::Row(5));
+    }
+
+    #[test]
+    fn row_accessor() {
+        assert_eq!(TableSelection::Row(2).row(), Some(2));
+        assert_eq!(TableSelection::Cell { row: 2, column: 4 }.row(), Some(2));
+        assert_eq!(TableSelection::Column(4).row(), None);
+    }
+
+    #[test]
+    fn column_accessor() {
+        assert_eq!(TableSelection::Column(4).column(), Some(4));
+        assert_eq!(TableSelection::Cell { row: 2, column: 4 }.column(), Some(4));
+        assert_eq!(TableSelection::Row(2).column(), None);
+    }
+
+    /// The renamed methods still accept a bare `usize` where the old ones did, so signature-
+    /// compatible call sites keep working without going through the deprecated aliases.
+    #[test]
+    fn builders_accept_bare_indices() {
+        let state = TableState::new()
+            .with_selected_row(3)
+            .with_selected_column(1);
+        assert_eq!(state.selected_cell(), Some((3, 1)));
+        assert_eq!(
+            TableState::new().with_selected_cell((2, 4)).selected_cell(),
+            Some((2, 4))
+        );
+        assert_eq!(
+            TableState::new()
+                .with_selection(TableSelection::Row(1))
+                .selection(),
+            Some(TableSelection::Row(1))
+        );
+    }
+
+    #[expect(deprecated)]
+    #[test]
+    fn deprecated_aliases_match_their_replacements() {
+        // Each alias must be observationally identical to the method it forwards to, including
+        // the offset reset that `select(None)` has always performed.
+        let mut old = TableState::new().with_selected(2);
+        let mut new = TableState::new().with_selected_row(2);
+        assert_eq!(old.selected(), new.selected_row());
+
+        for (apply_old, apply_new) in [
+            (
+                TableState::select_next as fn(&mut TableState),
+                TableState::select_next_row as fn(&mut TableState),
+            ),
+            (TableState::select_previous, TableState::select_previous_row),
+            (TableState::select_first, TableState::select_first_row),
+            (TableState::select_last, TableState::select_last_row),
+        ] {
+            apply_old(&mut old);
+            apply_new(&mut new);
+            assert_eq!(old, new);
+        }
+
+        old.select(None);
+        new.select_row(None);
+        assert_eq!(old, new);
     }
 }

--- a/tests/parity.rs
+++ b/tests/parity.rs
@@ -3,6 +3,8 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Flex, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, StatefulWidget, Widget};
+#[cfg(feature = "serde")]
+use ratatui_table::TableSelection;
 use ratatui_table::{Cell, HighlightSpacing, Row, Table, TableState};
 use ratatui_widgets::table as builtin;
 
@@ -92,7 +94,7 @@ fn renders_selection_and_scrolling_like_builtin_table() {
 
     assert_eq!(extracted_buffer, builtin_buffer);
     assert_eq!(extracted_state.offset(), builtin_state.offset());
-    assert_eq!(extracted_state.selected(), builtin_state.selected());
+    assert_eq!(extracted_state.selected_row(), builtin_state.selected());
     assert_eq!(
         extracted_state.selected_column(),
         builtin_state.selected_column()
@@ -124,6 +126,32 @@ fn handles_small_areas_like_builtin_table() {
     }
 }
 
+/// The default [`HighlightPlacement`] must lay out exactly like the built-in table: reserve the
+/// symbol column at the left edge and shift every column right by its width.
+#[test]
+fn default_highlight_placement_matches_builtin_table() {
+    let area = Rect::new(0, 0, 24, 4);
+    let widths = [Constraint::Length(6), Constraint::Length(6)];
+    let rows = ["a", "b", "c"];
+
+    let extracted = Table::new(rows.map(|r| Row::new([r, r])), widths)
+        .highlight_symbol(">> ")
+        .flex(Flex::Start);
+    let builtin = builtin::Table::new(rows.map(|r| builtin::Row::new([r, r])), widths)
+        .highlight_symbol(">> ")
+        .flex(Flex::Start);
+
+    let mut extracted_state = TableState::new().with_selected_row(1);
+    let mut builtin_state = builtin::TableState::new().with_selected(1);
+    let mut extracted_buffer = Buffer::empty(area);
+    let mut builtin_buffer = Buffer::empty(area);
+
+    StatefulWidget::render(extracted, area, &mut extracted_buffer, &mut extracted_state);
+    StatefulWidget::render(builtin, area, &mut builtin_buffer, &mut builtin_state);
+
+    assert_eq!(extracted_buffer, builtin_buffer);
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn serializes_state_with_serde_feature() {
@@ -134,4 +162,19 @@ fn serializes_state_with_serde_feature() {
     let round_trip: TableState = serde_json::from_str(&json).unwrap();
 
     assert_eq!(round_trip, state);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serializes_every_selection_arm() {
+    for selection in [
+        TableSelection::Row(1),
+        TableSelection::Column(2),
+        TableSelection::Cell { row: 3, column: 4 },
+    ] {
+        let state = TableState::new().with_selection(selection);
+        let json = serde_json::to_string(&state).unwrap();
+        let round_trip: TableState = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip, state);
+    }
 }


### PR DESCRIPTION
Closes #10. Ports https://github.com/ratatui/ratatui/pull/516 by @tonogdlp.

## What

`TableState` stores one `TableSelection` enum. Three variants, three real states:

```rust
pub enum TableSelection {
    Row(usize),
    Column(usize),
    Cell { row: usize, column: usize },
}
```

`HighlightPlacement` decides which columns get space for the highlight symbol. It was always column 0.

## Naming

Rule: every method names its axis. Unqualified names mean the whole selection.

| axis | get | set | build |
| --- | --- | --- | --- |
| whole | `selection` | `set_selection` | `with_selection` |
| row | `selected_row` | `select_row` | `with_selected_row` |
| column | `selected_column` | `select_column` | `with_selected_column` |
| cell | `selected_cell` | `select_cell` | `with_selected_cell` |

Navigation follows the same rule: `select_next_row`, `select_first_column`, and so on.

Deprecated aliases, one line each, nothing breaks: `selected`, `select`, `with_selected`, `select_next`, `select_previous`, `select_first`, `select_last`.

Two traps worth naming, both avoided:

- Not reusing `selected()` for the enum. `state.selected().is_some()` would keep compiling while flipping meaning from "a row is selected" to "anything is selected".
- No `Into<TableSelection>` bound on `select`. `select(Some(1))` would compile unchanged and silently drop the column.

## Breaking

`selected_mut()` and `selected_column_mut()` are gone. Both returned `&mut Option<usize>` pointing at a field that no longer exists. A deprecated fn must still compile, and no body can produce that reference into an enum discriminant. Deletion is forced. Replacement is `selection_mut()`.

Everything else is aliased.

**This needs a version bump.** `cargo semver-checks` fails the two removals against published `0.1.0`. `0.1.1` does not clear it — Cargo's 0.x rule makes the minor field the major, so a removal demands `0.2.0`. Bumped here, but `Cargo.toml` is yours: revert it if you would rather cut the release separately.

## Behavior changes

1. Any selection reserves the symbol column, not just a row selection. `SelectedColumn` has nowhere to draw otherwise. Visible only with `HighlightSpacing::WhenSelected` plus a column-only selection.
2. A column-only selection anchors its symbol to the first *visible* row. #516 used absolute row 0, so the symbol vanished once the table scrolled.

## AI Usage
AI is used to generate comment and docs.