### PR TITLE
chore: Update justfile to include default list

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,5 @@
 set shell := ["bash", "-uc"]
-
-default:
-    @just --list
+set default-list := true
 
 fmt:
     RUSTFMT="$(rustup which --toolchain nightly rustfmt)" cargo fmt --all


### PR DESCRIPTION
With recent versions of just, you can remove the default recipe when you are using it for a list with this syntax. The advantage is it doesn't show the default recipe as an option. Source: https://just.systems/man/en/the-default-recipe.html

Alternatively, you can add the `[private]` attribute:

```
[private]
default:
    @just --list
```

But the syntax in the PR is nicer imo.