### PR TITLE
docs: clarify contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,59 @@
 # Repository Guidelines
 
-## Project shape
+## Project Structure & Module Organization
 
-- This is a single Rust library crate. Keep Table behavior in `src/table.rs` and its existing
-  concept modules under `src/table/`.
-- Preserve the direct crate-root exports of `Table`, `Row`, `Cell`, `TableState`, and
-  `HighlightSpacing`.
-- Keep the crate usable with `no_std` plus `alloc`; gate standard-library behavior behind `std`.
+- `src/lib.rs`: crate documentation and public exports.
+- `src/table.rs`: rendering implementation.
+- `src/table/`: rows, cells, selection state, and highlight spacing.
+- Unit tests: beside implementation.
+- `tests/parity.rs`: rendering comparisons with the built-in widget.
 
-## Development
+Keep default builds usable with `no_std` plus `alloc`; gate standard-library behavior behind `std`.
 
-- Use `just --list` for local commands.
-- Run `just fmt-check`, `just clippy-all`, `just test`, and `just docs` before publication.
-- Add deterministic buffer-rendering tests for visible behavior and boundary cases.
-- Keep Rustdoc examples runnable and run `just rdme-check` after crate-level documentation changes.
+## Design Scope & Upstream Proposals
 
-## Changes and releases
+Consult the [Table evolution roadmap](https://github.com/ratatui/ratatui-table/issues/7) for current
+proposals and coordination with Ratatui.
 
-- Use Conventional Commits and keep one purpose per change.
-- Do not edit generated changelog entries; release-plz owns versions and release notes.
-- Treat `.github/`, release configuration, `Cargo.toml`, and `Cargo.lock` as maintainer-owned
-  release-sensitive paths.
+- Keep proposals independently reviewable and document migrations for breaking changes.
+- When porting upstream work, link its successor issue and preserve original authorship.
+- Consult prior reviews, tests, and design discussion; implementations may be redesigned.
+- Coordinate shared widget and core changes upstream; keep work here scoped to Table.
+
+## Build, Test, and Development Commands
+
+Use the Rust version and edition declared in [Cargo.toml](Cargo.toml). Formatting and docs require
+nightly:
+
+- `just fmt` / `just fmt-check`: apply or verify nightly rustfmt formatting.
+- `just clippy-all`: lint all targets and features on stable and beta, denying warnings.
+- `just test`: test all features, no default features, and serde without default features.
+- `just docs`: build Rustdoc with warnings denied.
+- `just rdme` / `just rdme-check`: regenerate or verify README content from crate documentation.
+- `just check-all`: run all local checks, including dependencies, semver, and packaging.
+- `markdownlint-cli2 "**/*.md"`: lint Markdown using repository configuration.
+
+## Coding Style & Naming Conventions
+
+- Follow `rustfmt.toml`: four-space indentation, `snake_case` functions/modules, `PascalCase` types.
+- Keep behavior understandable locally. Unsafe code is forbidden.
+- Document public APIs with runnable Rustdoc examples.
+- Wrap Markdown prose at 100 characters; separate headings, lists, and code blocks with blank lines.
+- Prefer lists for parallel items; use prose for connected explanations.
+- Keep guidance durable; link to roadmap issues for proposal details and current status.
+
+## Testing Guidelines
+
+- Use Rust tests, `rstest` for parameterized cases, and `pretty_assertions` for diffs.
+- Use behavior-based test names and deterministic buffer assertions for rendering and boundary cases.
+- Run `cargo test --test parity` for baseline comparisons; document intentional divergences.
+
+## Commit & Pull Request Guidelines
+
+Use Conventional Commits for commits and PR titles, e.g. `fix: correct selection rendering`.
+Keep PRs focused; describe behavior, validation, and linked issues. Discuss substantial changes in an
+issue first. Contributors with Write access may review and merge ordinary source work; see
+`CONTRIBUTING.md`.
+
+Maintainers review `.github/`, release configuration, `Cargo.toml`, and `Cargo.lock` changes.
+Release-plz owns versions and generated release notes; do not hand-edit changelog release entries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,21 @@ Thank you for helping evolve Ratatui's Table widget.
 
 ## Design and review
 
-For substantial or breaking changes, open or join an issue before implementation. Explain the use
-case, constraints, alternatives, and expected migration story. Keep each pull request focused on one
-reviewable behavior.
+For substantial or breaking changes, open or join an issue before implementation. Explain:
+
+- The use case and constraints.
+- Alternatives considered.
+- The expected migration story.
+
+Keep each pull request focused on one reviewable behavior and include:
+
+- The resulting behavior.
+- Validation performed.
+- Links to related issues.
+
+Consult the [Table evolution roadmap](https://github.com/ratatui/ratatui-table/issues/7) for current
+proposals and coordination with Ratatui. Keep proposals independently reviewable and document
+migrations for breaking changes.
 
 Contributors with Write access are encouraged to review each other's ordinary source changes. The
 Ratatui maintainers own repository security settings and release approval; changes to protected
@@ -15,20 +27,73 @@ release, workflow, manifest, and lockfile paths require maintainer review.
 Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) so release-plz can create
 versions and changelog entries. Pull request titles should use the same format.
 
+## Bringing work from Ratatui
+
+When porting an upstream proposal:
+
+- Link its successor issue.
+- Preserve the original author's attribution.
+- Use existing discussions, reviews, tests, and history to inform the proposal; you may revisit
+  the implementation rather than port it unchanged.
+- Keep upstream pull requests open until a successor exists or their authors agree to closure.
+
+Coordinate changes to shared widget behavior and core primitives in the main Ratatui repository.
+Keep work here scoped to Table; consult the roadmap for proposal-specific ownership.
+
 ## Development
 
-The main local checks are:
+Install these development prerequisites:
+
+- Rust meeting the version and edition requirements in [Cargo.toml](Cargo.toml).
+- `just` for development recipes.
+- Nightly for formatting and documentation.
+- Stable and beta with Clippy for `just clippy-all`.
+
+Run commands from the crate root. `cargo build` builds the library; the main local checks are:
 
 ```shell
-just fmt-check
-just clippy-all
-just test
-just docs
-just check-all
+just fmt-check   # Check nightly rustfmt formatting
+just clippy-all  # Lint all targets/features on stable and beta
+just test        # Test all features, no defaults, and serde without defaults
+just docs        # Build Rustdoc with warnings denied
+just check-all   # Run all local checks, including dependency and package checks
 ```
 
 Run `just --list` for the complete command list. CI also verifies the MSRV, minimal dependency
 floors, dependency policy, Markdown, spelling, package contents, and workflow security.
+
+### Code and tests
+
+The source layout is:
+
+- `src/lib.rs`: crate documentation and public exports.
+- `src/table.rs`: rendering implementation.
+- `src/table/`: rows, cells, selection state, and highlight spacing.
+
+Keep default builds usable with `no_std` plus `alloc`; gate standard-library behavior behind `std`.
+Unsafe code is forbidden.
+
+Follow `rustfmt.toml` and run `just fmt` to format changes. Use four-space indentation,
+`snake_case` functions/modules, and `PascalCase` types. Keep behavior understandable locally.
+
+For tests:
+
+- Add unit tests beside the implementation and use behavior-based names.
+- Use `rstest` for parameterized cases and `pretty_assertions` for readable diffs.
+- Cover rendering changes with deterministic buffer assertions and boundary cases.
+- Run `cargo test --test parity` to compare with the built-in widget, and document intentional
+  divergences from the baseline.
+
+### Documentation
+
+- Document public APIs with runnable Rustdoc examples.
+- After changing crate-level documentation, run `just rdme` to regenerate README content and
+  `just rdme-check` to verify it.
+- Wrap Markdown prose at 100 characters.
+- Separate headings, lists, and code blocks with blank lines.
+- Prefer lists for parallel items; use prose for connected explanations.
+- Keep guidance durable; link to roadmap issues for proposal details and current status.
+- Run `markdownlint-cli2 "**/*.md"`.
 
 Do not edit `CHANGELOG.md` for release entries. release-plz and git-cliff own generated release
 notes.


### PR DESCRIPTION
Expand AGENTS.md and CONTRIBUTING.md with repository layout, development commands, testing expectations, and upstream porting guidance. Link to the [Table evolution roadmap](https://github.com/ratatui/ratatui-table/issues/7) for evolving proposals while keeping the guides focused on durable contribution practices.

Use lists for parallel guidance and preserve authorship, migration, and maintainer review expectations.

Validation: `markdownlint-cli2 AGENTS.md CONTRIBUTING.md` passes. Documentation-only change.
